### PR TITLE
[FIX] emc: Let emc be installable

### DIFF
--- a/easy_my_coop/__manifest__.py
+++ b/easy_my_coop/__manifest__.py
@@ -1,21 +1,22 @@
 # Copyright 2013-2018 Open Architects Consulting SPRL.
-# Copyright 2018-Coop IT Easy SCRLfs (<http://www.coopiteasy.be>)
+# Copyright 2018-     Coop IT Easy SCRLfs (<http://www.coopiteasy.be>)
 # - Houssine BAKKALI - <houssine@coopiteasy.be>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
 {
     "name": "Easy My Coop",
     "version": "12.0.1.0.0",
-    "depends": ["base",
-                "sale",
-                "account",
-                "base_iban",
-                "product",
-                "partner_firstname",
-                "partner_contact_birthdate",
-                "partner_contact_address",
-                "email_template_config",
-                ],
+    "depends": [
+        "base",
+        "sale",
+        "account",
+        "base_iban",
+        "product",
+        "partner_firstname",
+        "partner_contact_birthdate",
+        "partner_contact_address",
+        "email_template_config",
+    ],
     "author": "Coop IT Easy SCRLfs",
     "category": "Cooperative management",
     "website": "https://www.coopiteasy.be",

--- a/easy_my_coop/__manifest__.py
+++ b/easy_my_coop/__manifest__.py
@@ -18,7 +18,7 @@
                 ],
     "author": "Coop IT Easy SCRLfs",
     "category": "Cooperative management",
-    "website": "www.coopiteasy.be",
+    "website": "https://www.coopiteasy.be",
     "license": "AGPL-3",
     "description": """
     This module allows to manage the cooperator subscription and all the

--- a/easy_my_coop/__manifest__.py
+++ b/easy_my_coop/__manifest__.py
@@ -28,7 +28,6 @@
         'security/easy_my_coop_security.xml',
         'security/ir.model.access.csv',
         'data/easy_my_coop_data.xml',
-        'data/mail_template_data.xml',
         'wizard/create_subscription_from_partner.xml',
         'wizard/update_partner_info.xml',
         'wizard/validate_subscription_request.xml',
@@ -47,6 +46,7 @@
         'report/cooperator_certificat_G001.xml',
         'report/cooperator_subscription_G001.xml',
         'report/cooperator_register_G001.xml',
+        'data/mail_template_data.xml',  # Must be loaded after reports
     ],
     'installable': True,
     'application': True,


### PR DESCRIPTION
The mail_tempalte_data must be loaded after the reports, else the
installation on a fresh install does not work.