### PR TITLE
9.0 unrequire some fields when logged

### DIFF
--- a/easy_my_coop/controllers/main.py
+++ b/easy_my_coop/controllers/main.py
@@ -6,7 +6,6 @@ import re
 from openerp import http
 from openerp.http import request
 from openerp.tools.translate import _
-from __builtin__ import list
 
 # Only use for behavior, don't stock it
 _TECHNICAL = ['view_from', 'view_callback']

--- a/easy_my_coop/controllers/main.py
+++ b/easy_my_coop/controllers/main.py
@@ -6,6 +6,7 @@ import re
 from openerp import http
 from openerp.http import request
 from openerp.tools.translate import _
+from __builtin__ import list
 
 # Only use for behavior, don't stock it
 _TECHNICAL = ['view_from', 'view_callback']
@@ -198,6 +199,11 @@ class WebsiteSubscription(http.Controller):
         product_id = kwargs.get("share_product_id")
         return prod_obj.sudo().browse(int(product_id)).product_variant_ids[0]
 
+    def remove_field_from_list(self, required_fields, field):
+        if required_fields.count(field) > 0:
+            required_fields.remove(field)
+        return required_fields
+
     def validation(self, kwargs, logged, values, post_file):
         user_obj = request.env['res.users']
         sub_req_obj = request.env['subscription.request']
@@ -223,6 +229,12 @@ class WebsiteSubscription(http.Controller):
 
         # Check that required field from model subscription_request exists
         required_fields = sub_req_obj.sudo().get_required_field()
+        if logged:
+            # these fields are readonly when logged
+            # we want to ease the process if user was a subscriber
+            self.remove_field_from_list(required_fields, 'iban')
+            self.remove_field_from_list(required_fields, 'birthdate')
+
         error = set(field for field in required_fields if not values.get(field)) #noqa
 
         if error:
@@ -262,13 +274,14 @@ class WebsiteSubscription(http.Controller):
                 return request.website.render(redirect, values)
 
         iban = kwargs.get("iban")
-        valid = sub_req_obj.check_iban(iban)
+        if iban:
+            valid = sub_req_obj.check_iban(iban)
 
-        if not valid:
-            values = self.fill_values(values, is_company, logged)
-            values["error_msg"] = _("You iban account number"
-                                    "is not valid")
-            return request.website.render(redirect, values)
+            if not valid:
+                values = self.fill_values(values, is_company, logged)
+                values["error_msg"] = _("You iban account number "
+                                        "is not valid")
+                return request.website.render(redirect, values)
 
         # check the subscription's amount
         max_amount = company.subscription_maximum_amount
@@ -365,8 +378,12 @@ class WebsiteSubscription(http.Controller):
         values["name"] = firstname + " " + lastname
         values["lastname"] = lastname
         values["firstname"] = firstname
-        values["birthdate"] = datetime.strptime(kwargs.get("birthdate"),
-                                                "%d/%m/%Y").date()
+        birthdate = kwargs.get("birthdate")
+        if birthdate:
+            values["birthdate"] = datetime.strptime(birthdate,
+                                                    ("%d/%m/%Y")).date()
+        else:
+            values["birthdate"] = False
         values["source"] = "website"
 
         values["share_product_id"] = self.get_selected_share(kwargs).id

--- a/easy_my_coop/models/coop.py
+++ b/easy_my_coop/models/coop.py
@@ -107,7 +107,9 @@ class subscription_request(models.Model):
     @api.depends('iban', 'skip_control_ng', 'is_company')
     def _validated_lines(self):
         for sub_request in self:
-            validated = self.check_iban(sub_request.iban)
+            validated = (self.check_iban(sub_request.iban)
+                         or sub_request.skip_control_ng
+                         )
             sub_request.validated = validated
 
     @api.multi

--- a/easy_my_coop_website_document/__openerp__.py
+++ b/easy_my_coop_website_document/__openerp__.py
@@ -15,7 +15,7 @@
     'author': 'Rémy Taymans',
     'license': 'AGPL-3',
     'version': '9.0.1.0',
-    'website': "https://github.com/houssine78/vertical-cooperative",
+    'website': "www.coopiteasy.be",
 
     'category': 'Website, Cooperative Management',
 

--- a/easy_my_coop_website_portal/__openerp__.py
+++ b/easy_my_coop_website_portal/__openerp__.py
@@ -15,7 +15,7 @@
     'author': 'Rémy Taymans',
     'license': 'AGPL-3',
     'version': '9.0.1.0',
-    'website': "https://github.com/houssine78/vertical-cooperative",
+    'website': "www.coopiteasy.be",
 
     'category': 'Website, Cooperative Management',
 

--- a/easy_my_coop_website_taxshelter/__openerp__.py
+++ b/easy_my_coop_website_taxshelter/__openerp__.py
@@ -15,7 +15,7 @@
     'author': 'Rémy Taymans',
     'license': 'AGPL-3',
     'version': '9.0.1.0',
-    'website': "https://github.com/houssine78/vertical-cooperative",
+    'website': "www.coopiteasy.be",
 
     'category': 'Website, Cooperative Management',
 

--- a/website_portal_extend/__openerp__.py
+++ b/website_portal_extend/__openerp__.py
@@ -16,7 +16,7 @@
     'author': 'Rémy Taymans',
     'license': 'AGPL-3',
     'version': '9.0.1.0',
-    'website': "https://github.com/houssine78/vertical-cooperative",
+    'website': "www.coopiteasy.be",
 
     'category': 'Website',
 


### PR DESCRIPTION
[FIX] When logged share personal data in the subscription form are set read only to avoid misleading the cooperator about his personal data been updated when subscribing new share.

Some of those fields may not be previously recorded (case where the cooperator in also a subscriber) so we set the field not required if the subscription form comes from a logged user.