### PR TITLE
[FIX] emc: replace no_registre by national_register_number

### DIFF
--- a/easy_my_coop/demo/coop.xml
+++ b/easy_my_coop/demo/coop.xml
@@ -39,7 +39,7 @@
     </record>
 
     <record id="bank_account_vincent_demo" model="res.partner.bank">
-            <field name="acc_number">BE68539007547034</field>
+            <field name="acc_number">BE71096123456769</field>
             <field name="bank_name">Bank</field>
             <field name="partner_id" ref="res_partner_cooperator_3_demo"/>
     </record>

--- a/easy_my_coop/demo/coop.xml
+++ b/easy_my_coop/demo/coop.xml
@@ -38,6 +38,12 @@
         <field name="country_id" ref="base.be"/>
     </record>
 
+    <record id="bank_account_vincent_demo" model="res.partner.bank">
+            <field name="acc_number">BE68539007547034</field>
+            <field name="bank_name">Bank</field>
+            <field name="partner_id" ref="res_partner_cooperator_3_demo"/>
+    </record>
+
     <record id="res_partner_cooperator_4_demo" model="res.partner">
         <field name="name">Rémy Commit</field>
         <field name="customer" eval="True"/>

--- a/easy_my_coop/models/partner.py
+++ b/easy_my_coop/models/partner.py
@@ -109,7 +109,6 @@ class ResPartner(models.Model):
                                ('female', 'Female'),
                                ('other', 'Other')],
                               string='Gender')
-    national_register_number = fields.Char(string='National Register Number')
     share_ids = fields.One2many('share.line',
                                 'partner_id',
                                 string='Share Lines')

--- a/easy_my_coop_export_xlsx/wizard/export_global_wizard.py
+++ b/easy_my_coop_export_xlsx/wizard/export_global_wizard.py
@@ -244,8 +244,6 @@ class export_global_report(models.TransientModel):
             i += 1
             worksheet2.write(j, i, sub_request.state)
             i += 1
-            worksheet2.write(j, i, sub_request.no_registre)
-            i += 1
             worksheet2.write(j, i, sub_request.email)
             i += 1
             worksheet2.write(j, i, sub_request.phone)

--- a/easy_my_coop_website/controllers/main.py
+++ b/easy_my_coop_website/controllers/main.py
@@ -13,16 +13,16 @@ _BLACKLIST = ['id', 'create_uid', 'create_date', 'write_uid', 'write_date',
               'user_id', 'active']
 
 _COOP_FORM_FIELD = ['email',  'confirm_email', 'firstname', 'lastname',
-                    'birthdate', 'iban', 'share_product_id', 'no_registre',
+                    'birthdate', 'iban', 'share_product_id',
                     'address', 'city', 'zip_code', 'country_id', 'phone',
                     'lang', 'nb_parts', 'total_parts', 'error_msg']
 
 _COMPANY_FORM_FIELD = ['is_company', 'company_register_number', 'company_name',
                        'company_email', 'confirm_email', 'email', 'firstname',
                        'lastname', 'birthdate', 'iban', 'share_product_id',
-                       'no_registre', 'address', 'city', 'zip_code',
-                       'country_id', 'phone', 'lang', 'nb_parts',
-                       'total_parts', 'error_msg', 'company_type']
+                       'address', 'city', 'zip_code', 'country_id', 'phone',
+                       'lang', 'nb_parts', 'total_parts', 'error_msg',
+                       'company_type']
 
 
 class WebsiteSubscription(http.Controller):


### PR DESCRIPTION
iwp_website is writing on _no_registre_ but is not defined in `easy_my_coop.subscription_request`