### PR TITLE
[9.0][ADD] emc: demo datas

### DIFF
--- a/easy_my_coop/__openerp__.py
+++ b/easy_my_coop/__openerp__.py
@@ -54,6 +54,9 @@
         'report/cooperator_register_G001.xml',
         'data/mail_template_data.xml',
     ],
+    'demo': [
+        'demo/coop.xml',
+    ],
     'installable': True,
     'application': True,
 }

--- a/easy_my_coop/demo/coop.xml
+++ b/easy_my_coop/demo/coop.xml
@@ -1,0 +1,173 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+     Copyright 2019 Coop IT Easy
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+-->
+<odoo>
+
+    <record id="res_partner_cooperator_1_demo" model="res.partner">
+        <field name="name">Virginie Leloup</field>
+        <field name="customer" eval="True"/>
+        <field name="member" eval="True"/>
+        <field name="is_company" eval="False"/>
+        <field name="email">virginie@demo.net</field>
+        <field name="street">Avenue des Dessus-de-Livres, 2</field>
+        <field name="city">Namur (Loyers)</field>
+        <field name="zip">5101</field>
+        <field name="country_id" ref="base.be"/>
+    </record>
+
+    <record id="res_partner_cooperator_2_demo" model="res.partner">
+        <field name="name">Houssine Intégrale</field>
+        <field name="customer" eval="True"/>
+        <field name="member" eval="True"/>
+        <field name="is_company" eval="False"/>
+        <field name="email">houssine@demo.net</field>
+        <field name="street">Avenue des Dessous-de-Livres, 3</field>
+        <field name="city">Namur (Loyers)</field>
+        <field name="zip">5101</field>
+        <field name="country_id" ref="base.be"/>
+    </record>
+
+    <record id="res_partner_cooperator_3_demo" model="res.partner">
+        <field name="name">Vincent Bixolon</field>
+        <field name="customer" eval="True"/>
+        <field name="member" eval="True"/>
+        <field name="is_company" eval="False"/>
+        <field name="email">vincent@demo.net</field>
+        <field name="street">Rue de la colocation, 23</field>
+        <field name="city">Namur (Loyers)</field>
+        <field name="zip">5101</field>
+        <field name="country_id" ref="base.be"/>
+    </record>
+
+    <record id="res_partner_cooperator_4_demo" model="res.partner">
+        <field name="name">Rémy Commit</field>
+        <field name="customer" eval="True"/>
+        <field name="member" eval="True"/>
+        <field name="is_company" eval="False"/>
+        <field name="email">remy@demo.net</field>
+        <field name="street">Rue Guido Van Rossum, 2</field>
+        <field name="city">Evere</field>
+        <field name="zip">5101</field>
+        <field name="country_id" ref="base.be"/>
+    </record>
+
+    <record id="res_partner_cooperator_5_demo" model="res.partner">
+        <field name="name">Anne de Brët</field>
+        <field name="customer" eval="True"/>
+        <field name="member" eval="True"/>
+        <field name="is_company" eval="False"/>
+        <field name="email">anne@demo.net</field>
+        <field name="street">Rue de la patrie, 6</field>
+        <field name="city">Nantes</field>
+        <field name="zip">44000</field>
+        <field name="country_id" ref="base.fr"/>
+    </record>
+
+    <record id="res_partner_cooperator_6_demo" model="res.partner">
+        <field name="name">Gildo Le Floch</field>
+        <field name="customer" eval="True"/>
+        <field name="member" eval="True"/>
+        <field name="is_company" eval="False"/>
+        <field name="email">gildo@demo.net</field>
+        <field name="street">Rue Printanière, 8</field>
+        <field name="city">Evere</field>
+        <field name="zip">5101</field>
+        <field name="country_id" ref="base.be"/>
+    </record>
+
+    <record id="bank_account_1_demo" model="res.partner.bank">
+            <field name="acc_number">FR7611808009101234567890147</field>
+            <field name="bank_name">Bank</field>
+            <field name="partner_id" ref="res_partner_cooperator_1_demo"/>
+    </record>
+
+    <record id="bank_account_2_demo" model="res.partner.bank">
+        <field name="acc_number">FR7630001007941234567890185</field>
+        <field name="bank_name">Bank</field>
+        <field name="partner_id" ref="res_partner_cooperator_2_demo"/>
+    </record>
+
+    <record id="bank_account_3_demo" model="res.partner.bank">
+        <field name="acc_number">BE71096123456769</field>
+        <field name="bank_name">Bank</field>
+        <field name="partner_id" ref="res_partner_cooperator_3_demo"/>
+    </record>
+
+    <record id="bank_account_4_demo" model="res.partner.bank">
+        <field name="acc_number">BE56596123456769</field>
+        <field name="bank_name">Bank</field>
+        <field name="partner_id" ref="res_partner_cooperator_4_demo"/>
+    </record>
+
+    <record id="bank_account_5_demo" model="res.partner.bank">
+        <field name="acc_number">FR7630001007958234567890186</field>
+        <field name="bank_name">Bank</field>
+        <field name="partner_id" ref="res_partner_cooperator_5_demo"/>
+    </record>
+
+    <record id="bank_account_6_demo" model="res.partner.bank">
+        <field name="acc_number">BE71096123753769</field>
+        <field name="bank_name">Bank</field>
+        <field name="partner_id" ref="res_partner_cooperator_6_demo"/>
+    </record>
+
+    <record id="account_cooperator_demo" model="account.account">
+        <field name="code">416000</field>
+        <field name="name">Cooperators</field>
+        <field name="user_type_id" ref="account.data_account_type_receivable"/>
+        <field name="reconcile" eval="True"/>
+    </record>
+
+    <record id="product_template_share_type_1_demo" model="product.template">
+        <field name="name">Part A - Founder</field>
+        <field name="short_name">Part A</field>
+        <field name="is_share" eval="True"/>
+        <field name="default_share_product" eval="True"/>
+        <field name="force_min_qty" eval="True"/>
+        <field name="minimum_quantity">2</field>
+        <field name="by_individual" eval="True"/>
+        <field name="by_company" eval="True"/>
+        <field name="list_price">50</field>
+        <field name="display_on_website" eval="True"/>
+    </record>
+
+    <record id="product_product_share_type_1_demo" model="product.product">
+        <field name="product_tmpl_id" ref="product_template_share_type_1_demo"/>
+        <field name="default_code">share_founder</field>
+    </record>
+
+    <record id="product_template_share_type_2_demo" model="product.template">
+        <field name="name">Part B - Worker</field>
+        <field name="short_name">Part B</field>
+        <field name="is_share" eval="True"/>
+        <field name="default_share_product" eval="True"/>
+        <field name="force_min_qty" eval="True"/>
+        <field name="minimum_quantity">2</field>
+        <field name="by_individual" eval="True"/>
+        <field name="by_company" eval="False"/>
+        <field name="list_price">25</field>
+        <field name="display_on_website" eval="True"/>
+    </record>
+
+    <record id="product_product_share_type_2_demo" model="product.product">
+        <field name="product_tmpl_id" ref="product_template_share_type_2_demo"/>
+        <field name="default_code">share_worker</field>
+    </record>
+
+    <record id="subscription_request_1_demo" model="subscription.request">
+        <field name="name">Manuel Dublues</field>
+        <field name="email">manuel@demo.net</field>
+        <field name="address">schaerbeekstraat</field>
+        <field name="zip_code">1111</field>
+        <field name="city">Brussels</field>
+        <field name="country_id" ref="base.be"/>
+        <field name="date" eval="datetime.now() - timedelta(days=12)"/>
+        <field name="source">manual</field>
+        <field name="ordered_parts">3</field>
+        <field name="share_product_id" ref="product_product_share_type_1_demo"/>
+        <field name="lang">en_US</field>
+    </record>
+
+</odoo>

--- a/easy_my_coop/demo/coop.xml
+++ b/easy_my_coop/demo/coop.xml
@@ -135,7 +135,7 @@
 
     <record id="product_product_share_type_1_demo" model="product.product">
         <field name="product_tmpl_id" ref="product_template_share_type_1_demo"/>
-        <field name="default_code">share_founder</field>
+        <field name="default_code">share_a</field>
     </record>
 
     <record id="product_template_share_type_2_demo" model="product.template">
@@ -153,7 +153,7 @@
 
     <record id="product_product_share_type_2_demo" model="product.product">
         <field name="product_tmpl_id" ref="product_template_share_type_2_demo"/>
-        <field name="default_code">share_worker</field>
+        <field name="default_code">share_b</field>
     </record>
 
     <record id="subscription_request_1_demo" model="subscription.request">

--- a/easy_my_coop/models/partner.py
+++ b/easy_my_coop/models/partner.py
@@ -84,7 +84,9 @@ class ResPartner(models.Model):
         for partner in self:
             share_type = ''
             for line in partner.share_ids:
-                share_type = str(line.share_product_id.default_code)
+                code = line.share_product_id.default_code
+                if code:
+                    share_type = str(code)
             if share_type != '':
                 partner.cooperator_type = share_type
 

--- a/easy_my_coop_eater/__openerp__.py
+++ b/easy_my_coop_eater/__openerp__.py
@@ -31,5 +31,8 @@
     'data': [
         'view/product_view.xml',
     ],
+    'demo': [
+        'demo/eaters.xml',
+    ],
     'installable': True,
 }

--- a/easy_my_coop_eater/demo/eaters.xml
+++ b/easy_my_coop_eater/demo/eaters.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+     Copyright 2019 Coop IT Easy
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+-->
+<odoo>
+
+    <record id="easy_my_coop.res_partner_cooperator_2_demo" model="res.partner">
+        <field name="eater">worker_eater</field>
+    </record>
+
+    <record id="easy_my_coop.res_partner_cooperator_3_demo" model="res.partner">
+        <field name="eater">worker_eater</field>
+    </record>
+
+    <record id="easy_my_coop.res_partner_cooperator_4_demo" model="res.partner">
+        <field name="eater">worker_eater</field>
+    </record>
+
+    <record id="easy_my_coop.res_partner_cooperator_5_demo" model="res.partner">
+        <field name="eater">worker_eater</field>
+    </record>
+
+    <record id="easy_my_coop.res_partner_cooperator_6_demo" model="res.partner">
+        <field name="eater">worker_eater</field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
Add demo datas created by @robinkeunen in 12.0 to `easy_my_coop`, see 5159337ffa1bc94bb2b6a6cf192c32fd2c432aab

Fix bug when no `share_product.default_code` was set as well.
