### PR TITLE
[FIX] fix uncovered use case

### DIFF
--- a/easy_my_coop/wizard/create_subscription_from_partner.py
+++ b/easy_my_coop/wizard/create_subscription_from_partner.py
@@ -133,6 +133,7 @@ class PartnerCreateSubscription(models.TransientModel):
 
         cooperator = self.cooperator
         vals = {'partner_id': cooperator.id,
+                'cooperator': True,
                 'share_product_id': self.share_product.id,
                 'ordered_parts': self.share_qty,
                 'user_id': self.env.uid,


### PR DESCRIPTION
when a subscription request is created from the wizard on a res partner
view. If the customer wasn't already cooperator, he wasn't flagged as
cooperator.