### PR TITLE
[FIX] emc: Report header hiding destinator's name

### DIFF
--- a/easy_my_coop/__manifest__.py
+++ b/easy_my_coop/__manifest__.py
@@ -28,6 +28,7 @@
     """,
     'data': [
         'data/easy_my_coop_data.xml',
+        'data/paperformat.xml',
         'security/res_groups.xml',
         'security/ir.model.access.csv',
         'wizard/create_subscription_from_partner.xml',

--- a/easy_my_coop/data/paperformat.xml
+++ b/easy_my_coop/data/paperformat.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="paperformat_emc_larger_logo" model="report.paperformat">
+        <field name="name">A4 easy my coop larger logo</field>
+        <field name="default" eval="True" />
+        <field name="format">A4</field>
+        <field name="page_height">0</field>
+        <field name="page_width">0</field>
+        <field name="orientation">Portrait</field>
+        <field name="margin_top">50</field>
+        <field name="margin_bottom">20</field>
+        <field name="margin_left">7</field>
+        <field name="margin_right">7</field>
+        <field name="header_line" eval="False" />
+        <field name="header_spacing">45</field>
+        <field name="dpi">90</field>
+    </record>
+
+</odoo>

--- a/easy_my_coop/report/layout.xml
+++ b/easy_my_coop/report/layout.xml
@@ -2,10 +2,6 @@
 <odoo>
 
     <template id="emc_external_layout_standard" inherit_id="web.external_layout_standard" primary="True">
-        <xpath expr="//div[hasclass('header')]//div//img" position="replace">
-            <img t-if="company.logo" t-att-src="image_data_uri(company.logo)" style="min-height: 75px; max-height: 75px" alt="Logo"/>
-        </xpath>
-
         <xpath expr="//div[hasclass('o_standard_footer')]" position="attributes">
             <attribute name="style">display: none;</attribute>
         </xpath>
@@ -40,6 +36,19 @@
                     </div>
                 </div>
             </div>
+        </xpath>
+    </template>
+
+    <template
+        id="emc_external_layout_larger_logo"
+        inherit_id="easy_my_coop.emc_external_layout_standard"
+        primary="True">
+        <!--
+        This template should be used with the special paperformat
+        that extend margin. See paperformat in data.
+        -->
+        <xpath expr="//div[hasclass('header')]//div//img" position="attributes">
+            <attribute name="style">min-height: 75px; max-height: 75px;</attribute>
         </xpath>
     </template>
 


### PR DESCRIPTION
Fix report with a larger logo. The issue was that the margin and header spacing where not good if the logo is enlarged. I separated the template with larger logo  and the standard template.