### PR TITLE
Add name attribute to div

### DIFF
--- a/easy_my_coop_website/views/subscription_template.xml
+++ b/easy_my_coop_website/views/subscription_template.xml
@@ -544,7 +544,7 @@
 		                          </t>
 		                      </select>
 		                    </div>
-			                <div class="form-group">
+			                <div name="share_div" class="form-group">
 								<table style="width:80%">			
 									<tr>
 										<td width="30%">


### PR DESCRIPTION
Having names on `div` elements make it easier to `xpath` them and customize.

Also for consistency with `becomecooperator` view, [here](https://github.com/coopiteasy/vertical-cooperative/blob/c7e96297a3aa9985a5bafac27bf27c8b98adbf50/easy_my_coop_website/views/subscription_template.xml#L219)

EDIT: probably `id` would be a better idea, but I didn't want to change too many things :sweat_smile: 