### PR TITLE
Allow company_register_number field to not be required

### DIFF
--- a/easy_my_coop_website/controllers/main.py
+++ b/easy_my_coop_website/controllers/main.py
@@ -371,7 +371,7 @@ class WebsiteSubscription(http.Controller):
         values["share_product_id"] = self.get_selected_share(kwargs).id
 
         if is_company:
-            if kwargs.get("company_register_number", is_company):
+            if kwargs.get("company_register_number"):
                 values["company_register_number"] = re.sub('[^0-9a-zA-Z]+',
                                                            '',
                                                            kwargs.get("company_register_number"))


### PR DESCRIPTION
In some case the [company_register_number](https://github.com/coopiteasy/vertical-cooperative/blob/12.0/easy_my_coop/models/coop.py#L285) field is not needed, for instance we totally remove it from the view [here](https://github.com/coopdevs/vertical-cooperative/blob/publish-es/easy_my_coop_es/views/become_company_cooperator_view.xml#L5) since it's not needed in our case.

The problem is that in the [controller](https://github.com/coopiteasy/vertical-cooperative/blob/12.0/easy_my_coop_website/controllers/main.py#L377) this field is still used due to a default value in the following [statement](https://github.com/coopiteasy/vertical-cooperative/blob/12.0/easy_my_coop_website/controllers/main.py#L374):
 ```python
if kwargs.get("company_register_number", is_company)
```

From my understanding this `if` statement will always return `true` since at that point `is_company` is always set.

So, if you don't fill the field, the server will return a 500 error complaining that `kwargs.get("company_register_number")` doesn't have that key.

The `is_company` default was introduced with [this commit](https://github.com/coopiteasy/vertical-cooperative/commit/14b23b53d20c9d1900e614440376eea1a192202f#diff-1db63750e862bd6ec1d199053fd9b128R208), but I could not get enough context to understand the reasoning.