### PR TITLE
[FIX] emc_taxshelter_report: send certificates

### DIFF
--- a/easy_my_coop_taxshelter_report/models/tax_shelter_declaration.py
+++ b/easy_my_coop_taxshelter_report/models/tax_shelter_declaration.py
@@ -256,7 +256,7 @@ class TaxShelterCertificate(models.Model):
 
     def generate_pdf_report(self, report_type):
         report, name = REPORT_DIC[report_type]
-        report = self.env.ref(report).render_qweb_pdf(self)
+        report = self.env.ref(report).render_qweb_pdf(self.id)[0]
         report = base64.b64encode(report)
         report_name = (
             self.partner_id.name + " " + name + " " + self.declaration_id.name + ".pdf"


### PR DESCRIPTION
Fixing an error when clicking the 'send certificate' button. The code behind this button had already been changed to v12.0 by #68 but wasn't tested.

This fix is inspired on [this](https://github.com/OCA/OCB/blob/13.0/addons/l10n_it_edi/models/account_invoice.py#L233) code.