### PR TITLE
Fix depends decorator of compute cooperator type function

### DIFF
--- a/easy_my_coop/models/partner.py
+++ b/easy_my_coop/models/partner.py
@@ -79,7 +79,9 @@ class ResPartner(models.Model):
         return [('', '')] + share_types
 
     @api.multi
-    @api.depends('share_ids')
+    @api.depends('share_ids', 'share_ids.share_product_id',
+                 'share_ids.share_product_id.default_code',
+                 'share_ids.share_number')
     def _compute_cooperator_type(self):
         for partner in self:
             share_type = ''


### PR DESCRIPTION
This is the same fix as in 9.0*, expanding the depends decorator in the compute function of the cooperator type field of `res.partner`.

* see commit f33fa6ec7f7f1ddc201c2eca758248ad3af2ae07