### PR TITLE
Check share to_company and to_individual on transfer

### DIFF
--- a/easy_my_coop/models/operation_request.py
+++ b/easy_my_coop/models/operation_request.py
@@ -199,11 +199,11 @@ class operation_request(models.Model):
                 raise ValidationError(_("This share type could not be"
                                         " transfered to " +
                                         self.partner_id_to.name))
-            if not self.receiver_not_member and self.partner_id_to.is_company \
+            if self.partner_id_to.is_company \
                     and not self.share_product_id.by_company:
                 raise ValidationError(_("This share can not be"
                                         " subscribed by a company"))
-            if not self.receiver_not_member and not self.partner_id_to.is_company \
+            if not self.partner_id_to.is_company \
                     and not self.share_product_id.by_individual:
                 raise ValidationError(_("This share can not be"
                                         " subscribed an individual"))

--- a/easy_my_coop/models/operation_request.py
+++ b/easy_my_coop/models/operation_request.py
@@ -199,6 +199,14 @@ class operation_request(models.Model):
                 raise ValidationError(_("This share type could not be"
                                         " transfered to " +
                                         self.partner_id_to.name))
+            if not self.receiver_not_member and self.partner_id_to.is_company \
+                    and not self.share_product_id.by_company:
+                raise ValidationError(_("This share can not be"
+                                        " subscribed by a company"))
+            if not self.receiver_not_member and not self.partner_id_to.is_company \
+                    and not self.share_product_id.by_individual:
+                raise ValidationError(_("This share can not be"
+                                        " subscribed an individual"))
             if self.receiver_not_member and self.subscription_request \
                     and not self.subscription_request.validated:
                 raise ValidationError(_("The information of the receiver"


### PR DESCRIPTION
Adding a check wether the to_individual/to_company settings of the type of share that is transfered correspond to the nature of the partner to which the transfer goes.

Same as #79 but for v12.