### PR TITLE
Ensure no partners are returned when company_register_number is not set

### DIFF
--- a/easy_my_coop/models/partner.py
+++ b/easy_my_coop/models/partner.py
@@ -179,5 +179,8 @@ class ResPartner(models.Model):
                                                ('email', '=', email)])
 
     def get_cooperator_from_crn(self, company_register_number):
+        if not company_register_number:
+            return None
+
         return self.env['res.partner'].search([('cooperator', '=', True),
                                                ('company_register_number', '=', company_register_number)])


### PR DESCRIPTION
Without this early return, this method would return an array of `Partner` where `cooperator` is `True` and `company_register_number` is not set.

The expected behavior is instead to return no `Partner`.

Related to https://github.com/coopiteasy/vertical-cooperative/pull/75.