### PR TITLE
[FIX] coop_it_easy: Pick right email template for payment confirmation

### DIFF
--- a/easy_my_coop/models/account_invoice.py
+++ b/easy_my_coop/models/account_invoice.py
@@ -100,17 +100,17 @@ class account_invoice(models.Model):
     def send_certificate_email(self, certificate_email_template, sub_reg_line):
         # we send the email with the certificate in attachment
         certificate_email_template.sudo().send_mail(self.partner_id.id, False)
-        
+
     def set_cooperator_effective(self, effective_date):
         sub_register_obj = self.env['subscription.register']
         share_line_obj = self.env['share.line']
+
+        certificate_email_template = self.get_mail_template_certificate()
 
         self.set_membership()
 
         sequence_operation = self.get_sequence_operation()
         sub_reg_operation = sequence_operation.next_by_id()
-
-        certificate_email_template = self.get_mail_template_certificate()
 
         for line in self.invoice_line_ids:
             sub_reg_vals = self.get_subscription_register_vals(line,


### PR DESCRIPTION
Commit https://github.com/coopiteasy/vertical-cooperative/commit/9a7cc8f5ff9fa315ba38fc7d3477c00b8cabd9fd#diff-c0573a661a1cd40bed5cd2c2841f7c5fL103 introduced a regression since `mail_template_id` was getting populated before the `Partner`'s attribute `member` is set to `True` or `False` by `self.set_membership()`.

With the current implementation, `certificate_email_template` will always be set as `easy_my_coop.email_template_certificat_increase` since `self.partner_id.member` will always be set to `True` at that point.

We need to check if the partner is already a member before we run `self.set_membership()`.