### PR TITLE
[ADD][9.0] easy_my_coop: effective date field on operation request

### DIFF
--- a/easy_my_coop/__openerp__.py
+++ b/easy_my_coop/__openerp__.py
@@ -4,7 +4,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 {
     "name": "Easy My Coop",
-    "version": "9.1.0.0.2",
+    "version": "9.1.0.0.3",
     "depends": ["base",
                 "sale",
                 "purchase",

--- a/easy_my_coop/i18n/fr_BE.po
+++ b/easy_my_coop/i18n/fr_BE.po
@@ -2136,6 +2136,11 @@ msgid "Request date"
 msgstr "Date de la demande"
 
 #. module: easy_my_coop
+#: model:ir.model.fields,field_description:easy_my_coop.field_operation_request_effective_date
+msgid "Effective date"
+msgstr "Date effective"
+
+#. module: easy_my_coop
 #: model:ir.ui.view,arch_db:easy_my_coop.view_subscription_request_filter
 msgid "Request type"
 msgstr "Type de demande"

--- a/easy_my_coop/models/operation_request.py
+++ b/easy_my_coop/models/operation_request.py
@@ -225,6 +225,7 @@ class operation_request(models.Model):
             effective_date = self.effective_date
         else:
             effective_date = self.get_date_now()
+            self.effective_date = effective_date
         sub_request = self.env['subscription.request']
 
         for rec in self:

--- a/easy_my_coop/models/operation_request.py
+++ b/easy_my_coop/models/operation_request.py
@@ -93,7 +93,9 @@ class operation_request(models.Model):
     def _constrain_effective_date(self):
         for obj in self:
             if obj.effective_date > fields.Datetime.now():
-                raise ValidationError("The effective date can not be in the future.")\
+                raise ValidationError(
+                    _("The effective date can not be in the future.")
+                )
 
     @api.multi
     def approve_operation(self):

--- a/easy_my_coop/models/operation_request.py
+++ b/easy_my_coop/models/operation_request.py
@@ -23,7 +23,7 @@ class operation_request(models.Model):
 
     request_date = fields.Date(string='Request date',
                                default=lambda self: self.get_date_now())
-    effective_date = fields.Date(string='Effective date', required=False)
+    effective_date = fields.Date(string='Effective date')
     partner_id = fields.Many2one('res.partner',
                                  string='Cooperator',
                                  domain=[('member', '=', True)],

--- a/easy_my_coop/models/operation_request.py
+++ b/easy_my_coop/models/operation_request.py
@@ -23,6 +23,7 @@ class operation_request(models.Model):
 
     request_date = fields.Date(string='Request date',
                                default=lambda self: self.get_date_now())
+    effective_date = fields.Date(string='Effective date', required=False)
     partner_id = fields.Many2one('res.partner',
                                  string='Cooperator',
                                  domain=[('member', '=', True)],
@@ -86,6 +87,13 @@ class operation_request(models.Model):
 
     invoice = fields.Many2one('account.invoice',
                               string="Invoice")
+
+    @api.multi
+    @api.constrains("effective_date")
+    def _constrain_effective_date(self):
+        for obj in self:
+            if obj.effective_date > fields.Datetime.now():
+                raise ValidationError("The effective date can not be in the future.")\
 
     @api.multi
     def approve_operation(self):
@@ -211,7 +219,10 @@ class operation_request(models.Model):
     def execute_operation(self):
         self.ensure_one()
 
-        effective_date = self.get_date_now()
+        if self.effective_date:
+            effective_date = self.effective_date
+        else:
+            effective_date = self.get_date_now()
         sub_request = self.env['subscription.request']
 
         for rec in self:

--- a/easy_my_coop/view/operation_request_view.xml
+++ b/easy_my_coop/view/operation_request_view.xml
@@ -33,6 +33,7 @@
 	       				<group>
 		       				<group>
 		       					<field name="request_date" attrs="{'readonly':[('state','!=','draft')]}"/>
+								<field name="effective_date" attrs="{'readonly':[('state','!=','draft')]}"/>
 			          			<field name="operation_type" attrs="{'readonly':[('state','!=','draft')]}"/>
 			          			<field name="receiver_not_member" attrs="{'invisible':[('operation_type','!=','transfer')]}"/>
 			          			<field name="partner_id" options="{'no_create':True}" attrs="{'readonly':[('state','!=','draft')]}"/>

--- a/easy_my_coop/view/operation_request_view.xml
+++ b/easy_my_coop/view/operation_request_view.xml
@@ -41,7 +41,7 @@
 			          			<field name="partner_id_to" options="{'no_create':True}" attrs="{'invisible':['|',('operation_type','!=','transfer'), ('receiver_not_member','=',True)],'readonly':[('state','!=','draft')]}"/>
 		       				</group>
 		       				<group>
-			          			<field name="user_id"/>,
+			          			<field name="user_id"/>
 			          			<field name="share_product_id" attrs="{'readonly':[('state','!=','draft')]}" widget="selection"/>
 			          			<field name="share_short_name" readonly="True"/>
 			          			<field name="share_to_product_id" attrs="{'invisible':[('operation_type','!=','convert')],'required':[('operation_type','=','convert')],'readonly':[('state','!=','draft')]}" widget="selection"/>

--- a/easy_my_coop/view/operation_request_view.xml
+++ b/easy_my_coop/view/operation_request_view.xml
@@ -6,11 +6,12 @@
             <field name="arch" type="xml">
                 <tree string="Operation requests" colors="green:state in ('approved'); blue:state in ('draft');grey: state in ('done')">
 	                <field name="request_date"/>
-          			<field name="partner_id"/>
-          			<field name="operation_type"/>
-          			<field name="quantity"/>
-          			<field name="user_id"/>
-          			<field name="state"/>
+			<field name="effective_date"/>
+			<field name="partner_id"/>
+			<field name="operation_type"/>
+			<field name="quantity"/>
+			<field name="user_id"/>
+			<field name="state"/>
                 </tree>
             </field>
         </record>

--- a/easy_my_coop/view/operation_request_view.xml
+++ b/easy_my_coop/view/operation_request_view.xml
@@ -35,12 +35,12 @@
 		       					<field name="request_date" attrs="{'readonly':[('state','!=','draft')]}"/>
 								<field name="effective_date" attrs="{'readonly':[('state','!=','draft')]}"/>
 			          			<field name="operation_type" attrs="{'readonly':[('state','!=','draft')]}"/>
-			          			<field name="receiver_not_member" attrs="{'invisible':[('operation_type','!=','transfer')]}"/>
+			          			<field name="receiver_not_member" attrs="{'invisible':[('operation_type','!=','transfer')],'readonly':[('state','!=','draft')]}"/>
 			          			<field name="partner_id" options="{'no_create':True}" attrs="{'readonly':[('state','!=','draft')]}"/>
-			          			<field name="partner_id_to" options="{'no_create':True}" attrs="{'invisible':['|',('operation_type','!=','transfer'), ('receiver_not_member','=',True)]}"/>
+			          			<field name="partner_id_to" options="{'no_create':True}" attrs="{'invisible':['|',('operation_type','!=','transfer'), ('receiver_not_member','=',True)],'readonly':[('state','!=','draft')]}"/>
 		       				</group>
 		       				<group>
-			          			<field name="user_id"/>
+			          			<field name="user_id"/>,
 			          			<field name="share_product_id" attrs="{'readonly':[('state','!=','draft')]}" widget="selection"/>
 			          			<field name="share_short_name" readonly="True"/>
 			          			<field name="share_to_product_id" attrs="{'invisible':[('operation_type','!=','convert')],'required':[('operation_type','=','convert')],'readonly':[('state','!=','draft')]}" widget="selection"/>


### PR DESCRIPTION
Adds an `effective_date` field to an operation request (no default, nor required, can't be in future). When set, this value is used in the subscription register and share line.

v12 version https://github.com/coopiteasy/vertical-cooperative/pull/94