### PR TITLE
[ADD][12.0] easy_my_coop: effective date field on operation request

### DIFF
--- a/easy_my_coop/__manifest__.py
+++ b/easy_my_coop/__manifest__.py
@@ -6,7 +6,7 @@
 {
     "name": "Easy My Coop",
     "summary": "Manage your cooperative shares",
-    "version": "12.0.3.0.1",
+    "version": "12.0.3.0.2",
     "depends": [
         "base",
         "web",

--- a/easy_my_coop/i18n/fr_BE.po
+++ b/easy_my_coop/i18n/fr_BE.po
@@ -1667,6 +1667,11 @@ msgid "Request date"
 msgstr "Date de la demande"
 
 #. module: easy_my_coop
+#: model:ir.model.fields,field_description:easy_my_coop.field_operation_request__effective_date
+msgid "Effective date"
+msgstr "Date effective"
+
+#. module: easy_my_coop
 #: model_terms:ir.ui.view,arch_db:easy_my_coop.theme_invoice_G002_document
 msgid "Request to Release Capital"
 msgstr ""

--- a/easy_my_coop/models/operation_request.py
+++ b/easy_my_coop/models/operation_request.py
@@ -336,6 +336,7 @@ class OperationRequest(models.Model):
             effective_date = self.effective_date
         else:
             effective_date = self.get_date_now()
+            self.effective_date = effective_date
         sub_request = self.env["subscription.request"]
 
         self.validate()

--- a/easy_my_coop/models/operation_request.py
+++ b/easy_my_coop/models/operation_request.py
@@ -29,6 +29,7 @@ class OperationRequest(models.Model):
     request_date = fields.Date(
         string="Request date", default=lambda self: self.get_date_now()
     )
+    effective_date = fields.Date(string='Effective date')
     partner_id = fields.Many2one(
         "res.partner",
         string="Cooperator",
@@ -117,6 +118,13 @@ class OperationRequest(models.Model):
     )
 
     invoice = fields.Many2one("account.invoice", string="Invoice")
+
+    @api.multi
+    @api.constrains("effective_date")
+    def _constrain_effective_date(self):
+        for obj in self:
+            if obj.effective_date > fields.Datetime.now():
+                raise ValidationError("The effective date can not be in the future.")\
 
     @api.multi
     def approve_operation(self):
@@ -322,7 +330,10 @@ class OperationRequest(models.Model):
     def execute_operation(self):
         self.ensure_one()
 
-        effective_date = self.get_date_now()
+        if self.effective_date:
+            effective_date = self.effective_date
+        else:
+            effective_date = self.get_date_now()
         sub_request = self.env["subscription.request"]
 
         self.validate()

--- a/easy_my_coop/models/operation_request.py
+++ b/easy_my_coop/models/operation_request.py
@@ -124,7 +124,9 @@ class OperationRequest(models.Model):
     def _constrain_effective_date(self):
         for obj in self:
             if obj.effective_date and obj.effective_date > fields.Date.today():
-                raise ValidationError("The effective date can not be in the future.")\
+                raise ValidationError(
+                    _("The effective date can not be in the future.")
+                )
 
     @api.multi
     def approve_operation(self):

--- a/easy_my_coop/models/operation_request.py
+++ b/easy_my_coop/models/operation_request.py
@@ -123,7 +123,7 @@ class OperationRequest(models.Model):
     @api.constrains("effective_date")
     def _constrain_effective_date(self):
         for obj in self:
-            if obj.effective_date > fields.Date.today():
+            if obj.effective_date and obj.effective_date > fields.Date.today():
                 raise ValidationError("The effective date can not be in the future.")\
 
     @api.multi

--- a/easy_my_coop/models/operation_request.py
+++ b/easy_my_coop/models/operation_request.py
@@ -123,7 +123,7 @@ class OperationRequest(models.Model):
     @api.constrains("effective_date")
     def _constrain_effective_date(self):
         for obj in self:
-            if obj.effective_date > fields.Datetime.now():
+            if obj.effective_date > fields.Date.today():
                 raise ValidationError("The effective date can not be in the future.")\
 
     @api.multi

--- a/easy_my_coop/views/operation_request_view.xml
+++ b/easy_my_coop/views/operation_request_view.xml
@@ -7,6 +7,7 @@
             <tree string="Operation requests"
                   colors="green:state in ('approved'); blue:state in ('draft');grey: state in ('done')">
                 <field name="request_date"/>
+                <field name="effective_date"/>
                 <field name="partner_id"/>
                 <field name="operation_type"/>
                 <field name="quantity"/>
@@ -49,13 +50,13 @@
                             <field name="operation_type"
                                    attrs="{'readonly':[('state','!=','draft')]}"/>
                             <field name="receiver_not_member"
-                                   attrs="{'invisible':[('operation_type','!=','transfer')]}"/>
+                                   attrs="{'invisible':[('operation_type','!=','transfer')], 'readonly':[('state','!=','draft')]}"/>
                             <field name="partner_id"
                                    options="{'no_create':True}"
                                    attrs="{'readonly':[('state','!=','draft')]}"/>
                             <field name="partner_id_to"
                                    options="{'no_create':True}"
-                                   attrs="{'invisible':['|',('operation_type','!=','transfer'), ('receiver_not_member','=',True)]}"/>
+                                   attrs="{'invisible':['|',('operation_type','!=','transfer'), ('receiver_not_member','=',True)], 'readonly':[('state','!=','draft')]}"/>
                         </group>
                         <group>
                             <field name="user_id"/>

--- a/easy_my_coop/views/operation_request_view.xml
+++ b/easy_my_coop/views/operation_request_view.xml
@@ -44,6 +44,8 @@
                         <group>
                             <field name="request_date"
                                    attrs="{'readonly':[('state','!=','draft')]}"/>
+                            <field name="effective_date"
+                                   attrs="{'readonly':[('state','!=','draft')]}"/>
                             <field name="operation_type"
                                    attrs="{'readonly':[('state','!=','draft')]}"/>
                             <field name="receiver_not_member"


### PR DESCRIPTION
Adds an `effective_date` field to an operation request (no default, nor required, can't be in future). When set, this value is used in the subscription register and share line.

Port of v9 version https://github.com/coopiteasy/vertical-cooperative/pull/93