### PR TITLE
Splits the address field in 2 fields (house number + street name) inthe subscription pages

### DIFF
--- a/easy_my_coop/i18n/ca_ES.po
+++ b/easy_my_coop/i18n/ca_ES.po
@@ -1855,7 +1855,7 @@ msgstr ""
 #: model_terms:ir.actions.act_window,help:easy_my_coop.action_partner_cooperator_candidate_form
 #: model_terms:ir.actions.act_window,help:easy_my_coop.action_partner_cooperator_form
 msgid ""
-"OpenERP helps you easily track all activities related to\n"
+"Odoo helps you easily track all activities related to\n"
 "                a cooperator: discussions, history of business opportunities,\n"
 "                documents, etc."
 msgstr ""
@@ -2715,7 +2715,7 @@ msgstr ""
 #. module: easy_my_coop
 #: code:addons/easy_my_coop/models/coop.py:427
 #, python-format
-msgid "You must set a cooperator account on you company."
+msgid "You must set a cooperator account on your company."
 msgstr ""
 
 #. module: easy_my_coop_website

--- a/easy_my_coop/i18n/fr.po
+++ b/easy_my_coop/i18n/fr.po
@@ -1478,7 +1478,7 @@ msgstr ""
 #: model_terms:ir.actions.act_window,help:easy_my_coop.action_company_representative_form
 #: model_terms:ir.actions.act_window,help:easy_my_coop.action_partner_cooperator_candidate_form
 #: model_terms:ir.actions.act_window,help:easy_my_coop.action_partner_cooperator_form
-msgid "OpenERP helps you easily track all activities related to\n"
+msgid "Odoo helps you easily track all activities related to\n"
 "                a cooperator: discussions, history of business opportunities,\n"
 "                documents, etc."
 msgstr ""
@@ -2262,7 +2262,7 @@ msgstr ""
 #: code:addons/coopiteasy/vertical-cooperative/easy_my_coop/models/coop.py:427
 #: code:addons/easy_my_coop/models/coop.py:427
 #, python-format
-msgid "You must set a cooperator account on you company."
+msgid "You must set a cooperator account on your company."
 msgstr ""
 
 #. module: easy_my_coop

--- a/easy_my_coop/i18n/fr_BE.po
+++ b/easy_my_coop/i18n/fr_BE.po
@@ -1478,7 +1478,7 @@ msgstr "Ancien cooperateur"
 #: model_terms:ir.actions.act_window,help:easy_my_coop.action_company_representative_form
 #: model_terms:ir.actions.act_window,help:easy_my_coop.action_partner_cooperator_candidate_form
 #: model_terms:ir.actions.act_window,help:easy_my_coop.action_partner_cooperator_form
-msgid "OpenERP helps you easily track all activities related to\n"
+msgid "Odoo helps you easily track all activities related to\n"
 "                a cooperator: discussions, history of business opportunities,\n"
 "                documents, etc."
 msgstr ""
@@ -2262,7 +2262,7 @@ msgstr ""
 #: code:addons/coopiteasy/vertical-cooperative/easy_my_coop/models/coop.py:427
 #: code:addons/easy_my_coop/models/coop.py:427
 #, python-format
-msgid "You must set a cooperator account on you company."
+msgid "You must set a cooperator account on your company."
 msgstr ""
 
 #. module: easy_my_coop

--- a/easy_my_coop/i18n/nl_BE.po
+++ b/easy_my_coop/i18n/nl_BE.po
@@ -436,8 +436,8 @@ msgstr "25"
 #. module: easy_my_coop
 #: code:addons/easy_my_coop/models/mail_mail.py:48
 #, python-format
-msgid "<p>Access this document <a href=\"%s\">directly in OpenERP</a></p>"
-msgstr "<p>Access this document <a href=\"%s\">directly in OpenERP</a></p>"
+msgid "<p>Access this document <a href=\"%s\">directly in Odoo</a></p>"
+msgstr "<p>Access this document <a href=\"%s\">directly in Odoo</a></p>"
 
 #. module: easy_my_coop
 #: model:ir.ui.view,arch_db:easy_my_coop.cooperator_certificat_G001_document
@@ -980,12 +980,12 @@ msgstr "Number of share"
 #: model:ir.actions.act_window,help:easy_my_coop.action_partner_cooperator_candidate_form
 #: model:ir.actions.act_window,help:easy_my_coop.action_partner_cooperator_form
 msgid ""
-"OpenERP helps you easily track all activities related to\n"
+"Odoo helps you easily track all activities related to\n"
 "                a cooperator: discussions, history of business "
 "opportunities,\n"
 "                documents, etc."
 msgstr ""
-"OpenERP helps you easily track all activities related to\n"
+"Odoo helps you easily track all activities related to\n"
 "                a cooperator: discussions, history of business "
 "opportunities,\n"
 "                documents, etc."
@@ -993,13 +993,13 @@ msgstr ""
 #. module: easy_my_coop
 #: model:ir.actions.act_window,help:easy_my_coop.action_invoice_tree_coop
 msgid ""
-"OpenERP's electronic invoicing allows to ease and fasten the\n"
+"Odoo's electronic invoicing allows to ease and fasten the\n"
 "                collection of cooperator payments. The cooperator customer "
 "receives the\n"
 "                invoice by email and he can pay online and/or import it\n"
 "                in his own system."
 msgstr ""
-"OpenERP's electronic invoicing allows to ease and fasten the\n"
+"Odoo's electronic invoicing allows to ease and fasten the\n"
 "                collection of cooperator payments. The cooperator customer "
 "receives the\n"
 "                invoice by email and he can pay online and/or import it\n"

--- a/easy_my_coop/models/coop.py
+++ b/easy_my_coop/models/coop.py
@@ -11,12 +11,15 @@ from addons.base_iban.models.res_partner_bank import validate_iban
 from odoo import _, api, fields, models
 from odoo.exceptions import UserError, ValidationError
 
+
+# Required fields when creating a subscription request
 _REQUIRED = [
     "email",
     "firstname",
     "lastname",
     "birthdate",
-    "address",
+    "street_number",
+    "street_name",
     "share_product_id",
     "ordered_parts",
     "zip_code",
@@ -255,7 +258,16 @@ class SubscriptionRequest(models.Model):
     )
     address = fields.Char(
         string="Address",
-        required=True,
+        readonly=True,
+        states={"draft": [("readonly", False)]},
+    )
+    street_name = fields.Char(
+        string="Street name",
+        readonly=True,
+        states={"draft": [("readonly", False)]},
+    )
+    street_number = fields.Char(
+        string="House number",
         readonly=True,
         states={"draft": [("readonly", False)]},
     )
@@ -440,6 +452,8 @@ class SubscriptionRequest(models.Model):
         self.birthdate = partner.birthdate_date
         self.gender = partner.gender
         self.address = partner.street
+        self.street_name = partner.street_name
+        self.street_number = partner.street_number
         self.city = partner.city
         self.zip_code = partner.zip
         self.country_id = partner.country_id
@@ -524,7 +538,7 @@ class SubscriptionRequest(models.Model):
                 account = accounts[0]
             else:
                 raise UserError(
-                    _("You must set a cooperator account on you company.")
+                    _("You must set a cooperator account on your company.")
                 )
         return account
 
@@ -565,6 +579,8 @@ class SubscriptionRequest(models.Model):
             "company_register_number": self.company_register_number,  # noqa
             "cooperator": True,
             "street": self.address,
+            "street_name": self.street_name,
+            "street_number": self.street_number,
             "zip": self.zip_code,
             "city": self.city,
             "email": self.company_email,
@@ -583,6 +599,8 @@ class SubscriptionRequest(models.Model):
             "firstname": self.firstname,
             "lastname": self.lastname,
             "street": self.address,
+            "street_name": self.street_name,
+            "street_number": self.street_number,
             "zip": self.zip_code,
             "email": self.email,
             "gender": self.gender,
@@ -607,6 +625,8 @@ class SubscriptionRequest(models.Model):
             "is_company": False,
             "cooperator": True,
             "street": self.address,
+            "street_name": self.street_name,
+            "street_number": self.street_number,
             "gender": self.gender,
             "zip": self.zip_code,
             "city": self.city,

--- a/easy_my_coop/views/res_partner_view.xml
+++ b/easy_my_coop/views/res_partner_view.xml
@@ -151,7 +151,7 @@
                     Click to add a contact in your address book.
                 </p>
                 <p>
-                    OpenERP helps you easily track all activities related to
+                    Odoo helps you easily track all activities related to
                     a cooperator: discussions, history of business
                     opportunities,
                     documents, etc.
@@ -176,7 +176,7 @@
                     Click to add a contact in your address book.
                 </p>
                 <p>
-                    OpenERP helps you easily track all activities related to
+                    Odoo helps you easily track all activities related to
                     a cooperator: discussions, history of business
                     opportunities,
                     documents, etc.
@@ -198,7 +198,7 @@
                     Click to add a contact in your address book.
                 </p>
                 <p>
-                    OpenERP helps you easily track all activities related to
+                    Odoo helps you easily track all activities related to
                     a cooperator: discussions, history of business
                     opportunities,
                     documents, etc.

--- a/easy_my_coop/views/subscription_request_view.xml
+++ b/easy_my_coop/views/subscription_request_view.xml
@@ -80,7 +80,8 @@
                                    attrs="{'invisible':[('is_company','=',False)]}"/>
                             <!-- todo highlight iban if not valid -->
                             <field name="iban"/>
-                            <field name="address"/>
+                            <field name="street_name"/>
+                            <field name="street_number"/>
                             <field name="zip_code"/>
                             <field name="city"/>
                             <field name="country_id"

--- a/easy_my_coop_website/__manifest__.py
+++ b/easy_my_coop_website/__manifest__.py
@@ -6,7 +6,12 @@
 {
     "name": "Easy My Coop Website",
     "version": "12.0.1.0.3",
-    "depends": ["easy_my_coop", "website", "website_recaptcha_reloaded"],
+    "depends": [
+        "easy_my_coop",
+        "website",
+        "website_recaptcha_reloaded",
+        "base_address_extended",
+    ],
     "author": "Coop IT Easy SCRLfs",
     "category": "Cooperative management",
     "website": "https://coopiteasy.be",

--- a/easy_my_coop_website/controllers/main.py
+++ b/easy_my_coop_website/controllers/main.py
@@ -7,7 +7,11 @@ from odoo.http import request
 from odoo.tools.translate import _
 
 # Only use for behavior, don't stock it
-_TECHNICAL = ["view_from", "view_callback"]
+_TECHNICAL = [
+    "view_from",
+    "view_callback"
+]
+
 # Allow in description
 _BLACKLIST = [
     "id",
@@ -19,6 +23,7 @@ _BLACKLIST = [
     "active",
 ]
 
+# The fields to be shown when someone wants to become a cooperator
 _COOP_FORM_FIELD = [
     "email",
     "confirm_email",
@@ -27,7 +32,8 @@ _COOP_FORM_FIELD = [
     "birthdate",
     "iban",
     "share_product_id",
-    "address",
+    "street_name",
+    "street_number",
     "city",
     "zip_code",
     "country_id",
@@ -38,6 +44,7 @@ _COOP_FORM_FIELD = [
     "error_msg",
 ]
 
+# The fields to be shown when a company wants to become a cooperator
 _COMPANY_FORM_FIELD = [
     "is_company",
     "company_register_number",
@@ -50,7 +57,8 @@ _COMPANY_FORM_FIELD = [
     "birthdate",
     "iban",
     "share_product_id",
-    "address",
+    "street_name",
+    "street_number",
     "city",
     "zip_code",
     "country_id",
@@ -133,6 +141,8 @@ class WebsiteSubscription(http.Controller):
             if partner.bank_ids:
                 values["iban"] = partner.bank_ids[0].acc_number
             values["address"] = partner.street
+            values["street_name"] = partner.street_name
+            values["street_number"] = partner.street_number
             values["zip_code"] = partner.zip
             values["city"] = partner.city
             values["country_id"] = partner.country_id.id
@@ -255,6 +265,7 @@ class WebsiteSubscription(http.Controller):
             is_company = True
             redirect = "easy_my_coop_website.becomecompanycooperator"
             email = kwargs.get("company_email")
+
         # TODO: Use a overloaded function with the captcha implementation
         if request.website.company_id.captcha_type == 'google':
             if (
@@ -395,6 +406,7 @@ class WebsiteSubscription(http.Controller):
 
         # List of file to add to ir_attachment once we have the ID
         post_file = []
+
         # Info to add after the message
         post_description = []
         values = {}
@@ -416,6 +428,7 @@ class WebsiteSubscription(http.Controller):
         logged = kwargs.get("logged") == "on"
         is_company = kwargs.get("is_company") == "on"
 
+	# Make sure all required info is present
         response = self.validation(kwargs, logged, values, post_file)
         if response is not True:
             return response

--- a/easy_my_coop_website/views/subscription_template.xml
+++ b/easy_my_coop_website/views/subscription_template.xml
@@ -261,13 +261,29 @@
                                            for="address">Address
                                     </label>
                                     <div class="col-md-7 col-sm-8">
-                                        <input type="text"
-                                               class="form-control mandatory-field"
-                                               name="address"
-                                               required="True"
-                                               t-att-readonly="logged"
-                                               t-attf-value="#{address or ''}"
-                                               placeholder="rue Van Hove, 19"/>
+                                        <table>
+                                            <tr>
+                                                <td width="15%">
+                                                    <input type="text"
+                                                        class="form-control mandatory-field"
+                                                        name="street_number"
+                                                        required="True"
+                                                        t-att-readonly="logged"
+                                                        t-attf-value="#{street_number or ''}"
+                                                        placeholder="19"/>
+                                                </td>
+                                                <td width="3%"></td>
+                                                <td>
+                                                    <input type="text"
+                                                        class="form-control mandatory-field"
+                                                        name="street_name"
+                                                        required="True"
+                                                        t-att-readonly="logged"
+                                                        t-attf-value="#{street_name or ''}"
+                                                        placeholder="rue Van Hove"/>
+                                                </td>
+                                            </tr>
+                                        </table>
                                     </div>
                                 </div>
 
@@ -650,13 +666,29 @@
                                            for="address">Address
                                     </label>
                                     <div class="col-md-7 col-sm-8">
-                                        <input type="text"
-                                               class="form-control mandatory-field"
-                                               name="address"
-                                               required="True"
-                                               t-att-readonly="logged"
-                                               t-attf-value="#{address or ''}"
-                                               placeholder="rue Van Hove, 19"/>
+                                        <table>
+                                            <tr>
+                                                <td width="15%">
+                                                    <input type="text"
+                                                        class="form-control mandatory-field"
+                                                        name="street_number"
+                                                        required="True"
+                                                        t-att-readonly="logged"
+                                                        t-attf-value="#{street_number or ''}"
+                                                        placeholder="19"/>
+                                                </td>
+                                                <td width="3%"></td>
+                                                <td>
+                                                    <input type="text"
+                                                        class="form-control mandatory-field"
+                                                        name="street_name"
+                                                        required="True"
+                                                        t-att-readonly="logged"
+                                                        t-attf-value="#{street_name or ''}"
+                                                        placeholder="rue Van Hove"/>
+                                                </td>
+                                            </tr>
+                                        </table>
                                     </div>
                                 </div>
 


### PR DESCRIPTION
Bonjour,

Voici ma PR pour la séparation du champ "adresse" en 2 en utilisant le module "base_address_extended".

Il y a encore 2-3 trucs à règler:

1. Rendre les champs "street_number" et "street_name" obligatoire (mais ça nécessite de mettre à jour la DB (lors de l'installation du module?) pour qu'il n'y ai pas de champ "street_number" ou "street_name" n'ayant pas de valeur (sinon on a un problème de contrainte SQL à l'installation du module) => Je ne sais pas comment il faut faire cela (utiliser l'attribut de champ "computed"?)
2. Il y  a encore quelques références au champ "adresse" que je n'ai pas encore mises à jour (car je ne sais pas encore à quoi ça correspond fonctionnellement). Il s'agit de rapports et de wizards dans le module "easy_my_coop" ainsi que d'une ligne dans le fichier "./views/subscription_template.xml" du module "easy_my_coop_website".
3. Ajouter les traductions.

Sinon, j'avoue que je suis un petit peu moins sur de moi sur cette PR de manière générale.

Dites moi ce que vous en pensez. 

Cyrille