### PR TITLE
Replaces the address field by 2 fields, "street_name" and "house_number"

### DIFF
--- a/easy_my_coop/models/coop.py
+++ b/easy_my_coop/models/coop.py
@@ -11,12 +11,14 @@ from addons.base_iban.models.res_partner_bank import validate_iban
 from odoo import _, api, fields, models
 from odoo.exceptions import UserError, ValidationError
 
+# This structure is only used in easy_my_coop_webstite's controller
 _REQUIRED = [
     "email",
     "firstname",
     "lastname",
     "birthdate",
-    "address",
+    "street_name",
+    "house_number",
     "share_product_id",
     "ordered_parts",
     "zip_code",
@@ -37,6 +39,7 @@ class SubscriptionRequest(models.Model):
     _name = "subscription.request"
     _description = "Subscription Request"
 
+    # This function is only used in easy_my_coop_webstite's controller
     def get_required_field(self):
         required_fields = _REQUIRED
         company = self.env["res.company"]._company_default_get()

--- a/easy_my_coop_website/controllers/main.py
+++ b/easy_my_coop_website/controllers/main.py
@@ -331,6 +331,9 @@ class WebsiteSubscription(http.Controller):
                     )
                     return request.render(redirect, values)
 
+        # There's no issue with the email, so we can remember the confirmation email
+        values["confirm_email"] = email
+
         company = request.website.company_id
         if company.allow_id_card_upload:
             if not post_file:

--- a/easy_my_coop_website/controllers/main.py
+++ b/easy_my_coop_website/controllers/main.py
@@ -7,7 +7,17 @@ from odoo.http import request
 from odoo.tools.translate import _
 
 # Only use for behavior, don't stock it
-_TECHNICAL = ["view_from", "view_callback"]
+_TECHNICAL = [
+    "view_from",
+    "view_callback"
+]
+
+# transient fields used to compute the address field
+_EXTRA_FIELDS = [
+    "street_name",
+    "house_number"
+]
+
 # Allow in description
 _BLACKLIST = [
     "id",
@@ -27,7 +37,8 @@ _COOP_FORM_FIELD = [
     "birthdate",
     "iban",
     "share_product_id",
-    "address",
+    "street_name",
+    "house_number",
     "city",
     "zip_code",
     "country_id",
@@ -50,7 +61,8 @@ _COMPANY_FORM_FIELD = [
     "birthdate",
     "iban",
     "share_product_id",
-    "address",
+    "street_name",
+    "house_number",
     "city",
     "zip_code",
     "country_id",
@@ -407,6 +419,11 @@ class WebsiteSubscription(http.Controller):
                 and field_name not in _BLACKLIST
             ):
                 values[field_name] = field_value
+            elif (
+                field_name in _EXTRA_FIELDS
+                and field_name not in _BLACKLIST
+            ):
+                values[field_name] = field_value
             # allow to add some free fields or blacklisted field like ID
             elif field_name not in _TECHNICAL:
                 post_description.append(
@@ -449,6 +466,10 @@ class WebsiteSubscription(http.Controller):
         values["source"] = "website"
 
         values["share_product_id"] = self.get_selected_share(kwargs).id
+
+        values["address"] = kwargs.get("street_name") + ", " + kwargs.get("house_number")
+        del values["street_name"]
+        del values["house_number"]
 
         if is_company:
             if kwargs.get("company_register_number", is_company):

--- a/easy_my_coop_website/views/subscription_template.xml
+++ b/easy_my_coop_website/views/subscription_template.xml
@@ -256,18 +256,34 @@
                                          style="margin-left:25%;margin-top:35px;width:59%"></div>
                                 </div>
 
-                                <div t-attf-class="form-group #{error and 'address' in error and 'has-error' or ''}">
+                                <div t-attf-class="form-group #{error and 'house_number' in error and 'has-error' or ''}">
                                     <label class="col-md-3 col-sm-4 control-label"
-                                           for="address">Address
+                                           for="house_number">Address
                                     </label>
                                     <div class="col-md-7 col-sm-8">
-                                        <input type="text"
-                                               class="form-control mandatory-field"
-                                               name="address"
-                                               required="True"
-                                               t-att-readonly="logged"
-                                               t-attf-value="#{address or ''}"
-                                               placeholder="rue Van Hove, 19"/>
+                                        <table>
+                                            <tr>
+                                                <td width="15%">
+                                                    <input type="text"
+                                                        class="form-control mandatory-field"
+                                                        name="house_number"
+                                                        required="True"
+                                                        t-att-readonly="logged"
+                                                        t-attf-value="#{house_number or ''}"
+                                                        placeholder="19"/>
+                                                </td>
+                                                <td width="3%"></td>
+                                                <td>
+                                                    <input type="text"
+                                                        class="form-control mandatory-field"
+                                                        name="street_name"
+                                                        required="True"
+                                                        t-att-readonly="logged"
+                                                        t-attf-value="#{street_name or ''}"
+                                                        placeholder="rue Van Hove"/>
+                                                </td>
+                                            </tr>
+                                        </table>
                                     </div>
                                 </div>
 
@@ -650,13 +666,29 @@
                                            for="address">Address
                                     </label>
                                     <div class="col-md-7 col-sm-8">
-                                        <input type="text"
-                                               class="form-control mandatory-field"
-                                               name="address"
-                                               required="True"
-                                               t-att-readonly="logged"
-                                               t-attf-value="#{address or ''}"
-                                               placeholder="rue Van Hove, 19"/>
+                                        <table>
+                                            <tr>
+                                                <td width="15%">
+                                                    <input type="text"
+                                                        class="form-control mandatory-field"
+                                                        name="house_number"
+                                                        required="True"
+                                                        t-att-readonly="logged"
+                                                        t-attf-value="#{street_number or ''}"
+                                                        placeholder="19"/>
+                                                </td>
+                                                <td width="3%"></td>
+                                                <td>
+                                                    <input type="text"
+                                                        class="form-control mandatory-field"
+                                                        name="street_name"
+                                                        required="True"
+                                                        t-att-readonly="logged"
+                                                        t-attf-value="#{street_name or ''}"
+                                                        placeholder="rue Van Hove"/>
+                                                </td>
+                                            </tr>
+                                        </table>
                                     </div>
                                 </div>
 


### PR DESCRIPTION
This is an alternative PR to https://github.com/coopiteasy/vertical-cooperative/pull/113, not using the base_address_extended module.

This is very simple and maybe a little bit "hacky" (because of the creation of the _EXTRA_FIELDS structure) but it works and all other solutions that add these 2 fields to the subscription.request model require much more extensive changes to keep the address field in sync with the street_name and house_number fields.

You may also see my branch at https://github.com/StCyr/vertical-cooperative/tree/20181114_166_simple for a (incomplete) solution that adds these 2 fields to the subscription.request model while not making use of the base_address_extended module. It's incomplete because I believe there are still places (eg: in a wizard) where users can directly fill the address field, while the solution is not able to update fields "street_name" and "house_number" (named "street_number" in that branch) from changes made to the "address" field. To do so, we would need to make sure the address field follow a specific format, always the same. The other solution would be to prevent users from filling the address field in all places of the code, but I'm not sure it's even possible when not using the "base_address_extended" module).

have a good brainstorming devising the best solution to take :)

BR,

Cyrille

