### PR TITLE
[12.0] [FIX] view representatives

### DIFF
--- a/easy_my_coop/models/partner.py
+++ b/easy_my_coop/models/partner.py
@@ -172,6 +172,10 @@ class ResPartner(models.Model):
         sting="Effective Date", compute=_compute_effective_date, store=True
     )
     representative = fields.Boolean(string="Legal Representative")
+    representative_of_member_company = fields.Boolean(
+        string="Legal Representative of Member Company",
+        compute="_compute_representative_of_member_company",
+    )
     subscription_request_ids = fields.One2many(
         "subscription.request", "partner_id", string="Subscription request"
     )
@@ -192,6 +196,19 @@ class ResPartner(models.Model):
                 is_candidate = bool(sub_requests)
 
             partner.coop_candidate = is_candidate
+
+    @api.multi
+    @api.depends("parent_id", "representative")
+    def _compute_fieldname(self):
+        for partner in self:
+            member_companies = self.env["res.partner"].search(
+                [("is_company", "=", True), ("member", "=", True)]
+            )
+            partner.representative_of_member_company = partner in member_companies.mapped(
+                "child_ids"
+            ).filtered(
+                "representative"
+            )
 
     @api.multi
     def has_representative(self):

--- a/easy_my_coop/models/partner.py
+++ b/easy_my_coop/models/partner.py
@@ -174,6 +174,7 @@ class ResPartner(models.Model):
     representative = fields.Boolean(string="Legal Representative")
     representative_of_member_company = fields.Boolean(
         string="Legal Representative of Member Company",
+        store=True,
         compute="_compute_representative_of_member_company",
     )
     subscription_request_ids = fields.One2many(
@@ -199,7 +200,7 @@ class ResPartner(models.Model):
 
     @api.multi
     @api.depends("parent_id", "representative")
-    def _compute_fieldname(self):
+    def _compute_representative_of_member_company(self):
         for partner in self:
             member_companies = self.env["res.partner"].search(
                 [("is_company", "=", True), ("member", "=", True)]

--- a/easy_my_coop/models/partner.py
+++ b/easy_my_coop/models/partner.py
@@ -205,10 +205,12 @@ class ResPartner(models.Model):
             member_companies = self.env["res.partner"].search(
                 [("is_company", "=", True), ("member", "=", True)]
             )
-            partner.representative_of_member_company = partner in member_companies.mapped(
-                "child_ids"
-            ).filtered(
-                "representative"
+            partner.representative_of_member_company = (
+                partner in member_companies.mapped(
+                    "child_ids"
+                ).filtered(
+                    "representative"
+                )
             )
 
     @api.multi

--- a/easy_my_coop/views/res_partner_view.xml
+++ b/easy_my_coop/views/res_partner_view.xml
@@ -31,8 +31,6 @@
                         <group>
                             <field name="representative"
                                    attrs="{'invisible':['|',('parent_id','=',False),('is_company','=',True)]}"/>
-                            <field name="representative_of_member_company"
-                                   attrs="{'invisible':['|',('parent_id','=',False),('is_company','=',True)]}"/>
                             <field name="cooperator_register_number"
                                    readonly="True"
                                    attrs="{'invisible':[('member','=',False)]}"/>

--- a/easy_my_coop/views/res_partner_view.xml
+++ b/easy_my_coop/views/res_partner_view.xml
@@ -31,6 +31,8 @@
                         <group>
                             <field name="representative"
                                    attrs="{'invisible':['|',('parent_id','=',False),('is_company','=',True)]}"/>
+                            <field name="representative_of_member_company"
+                                   attrs="{'invisible':['|',('parent_id','=',False),('is_company','=',True)]}"/>
                             <field name="cooperator_register_number"
                                    readonly="True"
                                    attrs="{'invisible':[('member','=',False)]}"/>
@@ -191,7 +193,7 @@
             <field name="res_model">res.partner</field>
             <field name="view_type">form</field>
             <field name="view_mode">kanban,tree,form</field>
-            <field name="domain">[('cooperator','=',True),('representative','=',True)]</field>
+            <field name="domain">[('representative_of_member_company','=',True)]</field>
             <field name="filter" eval="True"/>
             <field name="help" type="html">
                 <p class="oe_view_nocontent_create">


### PR DESCRIPTION
Fixing the view of representatives: from "all partners that are representatives and cooperatives themselves" to "all partners that are representatives and belong to a company that is `member`"