### PR TITLE
[9.0] [FIX] tax shelter declaration exclusion

### DIFF
--- a/easy_my_coop_taxshelter_report/models/tax_shelter_declaration.py
+++ b/easy_my_coop_taxshelter_report/models/tax_shelter_declaration.py
@@ -62,11 +62,11 @@ class TaxShelterDeclaration(models.Model):
 
     def _excluded_from_declaration(self, entry):
         if entry.date >= self.date_from and entry.date <= self.date_to:
-            declaration = self
+            declarations = self
         else:
-            declaration = self.search([('date_from', '<=', entry.date),
+            declarations = self.search([('date_from', '<=', entry.date),
                                        ('date_to', '>=', entry.date)])
-        if entry.partner_id.id in declaration.excluded_cooperator.ids:
+        if entry.partner_id.id in declarations.mapped('excluded_cooperator').ids:
             return True
         return False
 

--- a/easy_my_coop_taxshelter_report/models/tax_shelter_declaration.py
+++ b/easy_my_coop_taxshelter_report/models/tax_shelter_declaration.py
@@ -61,6 +61,7 @@ class TaxShelterDeclaration(models.Model):
                                            "as non eligible")
 
     def _excluded_from_declaration(self, entry):
+        # entry is a subscription.register object
         if entry.date >= self.date_from and entry.date <= self.date_to:
             declarations = self
         else:


### PR DESCRIPTION
Fix for an error encountered with a client who had multiple tax shelter declarations for the same period, and hence multiple declarations where returned by the `search` on line 67.

Side note/question: I don't understand why on line 64 we compare `entry.date` to the `date_from` and `date_to` of self (which results in `self` being returned - although there might be other declarations overlapping), but in case `else` we do a general search on all `tax.shelter.declaration` objects comparing `self.date_from` to `date_from` and `date_to` of all declarations. I'm not 100% acquainted with this code, but feels like a more general approach could work here. 
Or should there be a check in the system to prevent overlapping declarations?
cc @houssine78 ?

This branch is currently not deployed in test (since hotfix for client was done by generating declarations locally). I will deploy this in case this PR is validated.