### PR TITLE
[FIX] easy_my_coop_ch : validate button must appear when no iban

### DIFF
--- a/easy_my_coop_ch/models/coop.py
+++ b/easy_my_coop_ch/models/coop.py
@@ -23,3 +23,8 @@ class SubscriptionRequest(models.Model):
             req_fields.remove("iban")
 
         return req_fields
+
+    def check_iban(self, iban):
+        if iban:
+            return super(SubscriptionRequest, self).check_iban(iban)
+        return True


### PR DESCRIPTION
[Task](https://gestion.coopiteasy.be/web#id=5336&view_type=form&model=project.task&action=475&active_id=158)

 In `easy_my_coop_ch`, we need to return True in case there is no `iban`. Core doesn't do that: 
```python
    def check_iban(self, iban):
        try:
            if iban:
                validate_iban(iban)
                return True
            else:
                return False
        except ValidationError:
            return False
```
`Validate` button must appear even if no `iban` is specified