### PR TITLE
[12.0][FIX] easy_my_coop_loan: fix email template search

### DIFF
--- a/easy_my_coop_loan/data/mail_template_data.xml
+++ b/easy_my_coop_loan/data/mail_template_data.xml
@@ -129,6 +129,7 @@
 
         <record id="email_template_loan_confirm_paid" model="mail.template">
             <field name="name">Loan Issue Confirm Payment Received - Send by Email</field>
+            <field name="template_key">loan_payment_req</field>
             <field name="email_from">
                 ${(object.company_id.coop_email_contact or object.loan_issue_id.user_id.email)|safe}
             </field>


### PR DESCRIPTION
Fixing error introduced by #130. The `get_confirm_paid_email_template()` function is overwritten in the `investor_wallet_platform_base` module, and required the email template to have the key `template_key = 'loan_payment_received'`.