### PR TITLE
[FIX] easy_my_coop: respresentatives view depends

### DIFF
--- a/easy_my_coop/models/partner.py
+++ b/easy_my_coop/models/partner.py
@@ -178,7 +178,7 @@ class ResPartner(models.Model):
             partner.coop_candidate = is_candidate
 
     @api.multi
-    @api.depends("parent_id", "representative")
+    @api.depends("parent_id", "parent_id.member", "representative")
     def _compute_representative_of_member_company(self):
         for partner in self:
             member_companies = self.env["res.partner"].search(


### PR DESCRIPTION
[Task](https://gestion.coopiteasy.be/web?token=R0Qs92cjQIn6BsLb5XTZ&db=coopiteasy#id=5045&view_type=form&model=project.task&action=479)

The stored and computed field `representative_of_member_company` on partners was not computed when the parent company becomes a member, and therefore didn't show up in the `action_company_representative_form` views.

This PR Make _compute_representative_of_member_company depend on `parent_id.member`.

V12 version: https://github.com/coopiteasy/vertical-cooperative/pull/140