### PR TITLE
[12.0][ADD] emc_loan: field paid_amount

### DIFF
--- a/easy_my_coop_loan/__manifest__.py
+++ b/easy_my_coop_loan/__manifest__.py
@@ -4,7 +4,7 @@
 
 {
     "name": "Easy My Coop Bond and Subordinated Loan Issues",
-    "version": "12.0.1.0.1",
+    "version": "12.0.1.0.2",
     "depends": ["easy_my_coop"],
     "author": "Coop IT Easy SCRLfs",
     "category": "Cooperative management",

--- a/easy_my_coop_loan/views/loan_view.xml
+++ b/easy_my_coop_loan/views/loan_view.xml
@@ -16,6 +16,7 @@
                 <field name="minimum_amount"/>
                 <field name="maximum_amount"/>
                 <field name="subscribed_amount"/>
+                <field name="paid_amount"/>
                 <field name="user_id"/>
                 <field name="state"/>
             </tree>
@@ -74,6 +75,7 @@
                             <field name="minimum_amount"/>
                             <field name="maximum_amount"/>
                             <field name="subscribed_amount"/>
+                            <field name="paid_amount"/>
                             <field name="by_individual"/>
                             <field name="min_amount_person"
                                    attrs="{'invisible':[('by_individual','=',False)]}"/>


### PR DESCRIPTION
###  [Task](https://gestion.coopiteasy.be/web#id=5703&view_type=form&model=project.task&action=479)

- renamed `_compute_subscribed_amount` into `_compute_amounts`
  to compute both subscribed and paid amount.
- added field `paid_amount` both in form and tree view.
- bumped manifest