### PR TITLE
Make confirmation and certificate email optional

### DIFF
--- a/easy_my_coop/models/account_invoice.py
+++ b/easy_my_coop/models/account_invoice.py
@@ -113,8 +113,9 @@ class AccountInvoice(models.Model):
         return True
 
     def send_certificate_email(self, certificate_email_template, sub_reg_line):
-        # we send the email with the certificate in attachment
-        certificate_email_template.sudo().send_mail(self.partner_id.id, False)
+        if self.company_id.send_certificate_email:
+            # we send the email with the certificate in attachment
+            certificate_email_template.sudo().send_mail(self.partner_id.id, False)
 
     def set_cooperator_effective(self, effective_date):
         sub_register_obj = self.env["subscription.register"]

--- a/easy_my_coop/models/company.py
+++ b/easy_my_coop/models/company.py
@@ -93,6 +93,7 @@ class ResCompany(models.Model):
         help="Text to display aside the checkbox to approve financial risk.",
     )
     send_certificate_email = fields.Boolean(string="Send certificate email", default=True)
+    send_confirmation_email = fields.Boolean(string="Send confirmation email", default=True)
 
     @api.onchange("data_policy_approval_required")
     def onchange_data_policy_approval_required(self):

--- a/easy_my_coop/models/company.py
+++ b/easy_my_coop/models/company.py
@@ -94,6 +94,7 @@ class ResCompany(models.Model):
     )
     send_certificate_email = fields.Boolean(string="Send certificate email", default=True)
     send_confirmation_email = fields.Boolean(string="Send confirmation email", default=True)
+    send_capital_release_email = fields.Boolean(string="Send Capital Release email", default=True)
 
     @api.onchange("data_policy_approval_required")
     def onchange_data_policy_approval_required(self):

--- a/easy_my_coop/models/company.py
+++ b/easy_my_coop/models/company.py
@@ -92,9 +92,18 @@ class ResCompany(models.Model):
         translate=True,
         help="Text to display aside the checkbox to approve financial risk.",
     )
-    send_certificate_email = fields.Boolean(string="Send certificate email", default=True)
-    send_confirmation_email = fields.Boolean(string="Send confirmation email", default=True)
-    send_capital_release_email = fields.Boolean(string="Send Capital Release email", default=True)
+    send_certificate_email = fields.Boolean(
+        string="Send certificate email",
+        default=True
+    )
+    send_confirmation_email = fields.Boolean(
+        string="Send confirmation email",
+        default=True
+    )
+    send_capital_release_email = fields.Boolean(
+        string="Send Capital Release email",
+        default=True
+    )
 
     @api.onchange("data_policy_approval_required")
     def onchange_data_policy_approval_required(self):

--- a/easy_my_coop/models/company.py
+++ b/easy_my_coop/models/company.py
@@ -92,6 +92,7 @@ class ResCompany(models.Model):
         translate=True,
         help="Text to display aside the checkbox to approve financial risk.",
     )
+    send_certificate_email = fields.Boolean(string="Send certificate email", default=True)
 
     @api.onchange("data_policy_approval_required")
     def onchange_data_policy_approval_required(self):

--- a/easy_my_coop/models/coop.py
+++ b/easy_my_coop/models/coop.py
@@ -516,10 +516,11 @@ class SubscriptionRequest(models.Model):
     def send_capital_release_request(self, invoice):
         email_template = self.get_capital_release_mail_template()
 
-        # we send the email with the capital release request in attachment
-        # TODO remove sudo() and give necessary access right
-        email_template.sudo().send_mail(invoice.id, True)
-        invoice.sent = True
+        if self.company_id.send_capital_release_email:
+            # we send the email with the capital release request in attachment
+            # TODO remove sudo() and give necessary access right
+            email_template.sudo().send_mail(invoice.id, True)
+            invoice.sent = True
 
     def get_journal(self):
         return self.env.ref("easy_my_coop.subscription_journal")

--- a/easy_my_coop/models/coop.py
+++ b/easy_my_coop/models/coop.py
@@ -89,8 +89,9 @@ class SubscriptionRequest(models.Model):
             cooperator.write({"cooperator": True})
         subscr_request = super(SubscriptionRequest, self).create(vals)
 
-        mail_template_notif = subscr_request.get_mail_template_notif(False)
-        mail_template_notif.send_mail(subscr_request.id)
+        if self._send_confirmation_email():
+            mail_template_notif = subscr_request.get_mail_template_notif(False)
+            mail_template_notif.send_mail(subscr_request.id)
 
         return subscr_request
 
@@ -107,10 +108,11 @@ class SubscriptionRequest(models.Model):
                 vals["already_cooperator"] = True
         subscr_request = super(SubscriptionRequest, self).create(vals)
 
-        confirmation_mail_template = subscr_request.get_mail_template_notif(
-            True
-        )
-        confirmation_mail_template.send_mail(subscr_request.id)
+        if self._send_confirmation_email():
+            confirmation_mail_template = subscr_request.get_mail_template_notif(
+                True
+            )
+            confirmation_mail_template.send_mail(subscr_request.id)
 
         return subscr_request
 
@@ -760,6 +762,8 @@ class SubscriptionRequest(models.Model):
         waiting_list_mail_template.send_mail(self.id, True)
         self.write({"state": "waiting"})
 
+    def _send_confirmation_email(self):
+        return self.company_id.send_confirmation_email
 
 # todo move to share_line.py
 class ShareLine(models.Model):

--- a/easy_my_coop/models/coop.py
+++ b/easy_my_coop/models/coop.py
@@ -90,7 +90,7 @@ class SubscriptionRequest(models.Model):
         subscr_request = super(SubscriptionRequest, self).create(vals)
 
         if self._send_confirmation_email():
-            mail_template_notif = subscr_request.get_mail_template_notif(False)
+            mail_template_notif = subscr_request.get_mail_template_notif(is_company=False)
             mail_template_notif.send_mail(subscr_request.id)
 
         return subscr_request
@@ -110,7 +110,7 @@ class SubscriptionRequest(models.Model):
 
         if self._send_confirmation_email():
             confirmation_mail_template = subscr_request.get_mail_template_notif(
-                True
+                is_company=True
             )
             confirmation_mail_template.send_mail(subscr_request.id)
 

--- a/easy_my_coop/readme/ROADMAP.rst
+++ b/easy_my_coop/readme/ROADMAP.rst
@@ -1,0 +1,1 @@
+Gather and consolidate all easy_my_coop settings in the application parameters.

--- a/easy_my_coop/views/res_company_view.xml
+++ b/easy_my_coop/views/res_company_view.xml
@@ -32,6 +32,7 @@
                     <field name="financial_risk_approval_required"/>
                     <field name="financial_risk_approval_text"/>
                     <field name="send_confirmation_email"/>
+                    <field name="send_capital_release_email"/>
                     <field name="send_certificate_email"/>
                 </group>
             </group>

--- a/easy_my_coop/views/res_company_view.xml
+++ b/easy_my_coop/views/res_company_view.xml
@@ -31,6 +31,7 @@
                     <field name="display_financial_risk_approval"/>
                     <field name="financial_risk_approval_required"/>
                     <field name="financial_risk_approval_text"/>
+                    <field name="send_certificate_email"/>
                 </group>
             </group>
         </field>

--- a/easy_my_coop/views/res_company_view.xml
+++ b/easy_my_coop/views/res_company_view.xml
@@ -31,6 +31,7 @@
                     <field name="display_financial_risk_approval"/>
                     <field name="financial_risk_approval_required"/>
                     <field name="financial_risk_approval_text"/>
+                    <field name="send_confirmation_email"/>
                     <field name="send_certificate_email"/>
                 </group>
             </group>


### PR DESCRIPTION
Create three boolean fields in Company to choose if we want to send the confirmation, capital release and certificate emails in SubscriptionRequest flow.