### PR TITLE
[IMP] add a generic approval field to display on the subscription form

### DIFF
--- a/easy_my_coop/models/company.py
+++ b/easy_my_coop/models/company.py
@@ -92,6 +92,18 @@ class ResCompany(models.Model):
         translate=True,
         help="Text to display aside the checkbox to approve financial risk.",
     )
+    display_generic_rules_approval = fields.Boolean(
+        help="Choose to display generic rules checkbox on the"
+        " cooperator website form."
+    )
+    generic_rules_approval_required = fields.Boolean(
+        string="Is generic rules approval required?"
+    )
+    generic_rules_approval_text = fields.Html(
+        translate=True,
+        help="Text to display aside the checkbox to approve the "
+        "generic rules.",
+    )
     send_certificate_email = fields.Boolean(
         string="Send certificate email",
         default=True
@@ -119,3 +131,8 @@ class ResCompany(models.Model):
     def onchange_financial_risk_approval_required(self):
         if self.financial_risk_approval_required:
             self.display_financial_risk_approval = True
+
+    @api.onchange("generic_rules_approval_required")
+    def onchange_generic_rules_approval_required(self):
+        if self.generic_rules_approval_required:
+            self.display_generic_rules_approval = True

--- a/easy_my_coop/models/coop.py
+++ b/easy_my_coop/models/coop.py
@@ -48,6 +48,8 @@ class SubscriptionRequest(models.Model):
             required_fields.append("internal_rules_approved")
         if company.financial_risk_approval_required:
             required_fields.append("financial_risk_approved")
+        if company.generic_rules_approval_required:
+            required_fields.append("generic_rules_approved")
         return required_fields
 
     def get_mail_template_notif(self, is_company=False):
@@ -87,7 +89,7 @@ class SubscriptionRequest(models.Model):
         subscr_request = super(SubscriptionRequest, self).create(vals)
 
         if self._send_confirmation_email():
-            mail_template_notif = subscr_request.get_mail_template_notif(is_company=False)
+            mail_template_notif = subscr_request.get_mail_template_notif(is_company = False) #noqa
             mail_template_notif.send_mail(subscr_request.id)
 
         return subscr_request
@@ -436,6 +438,9 @@ class SubscriptionRequest(models.Model):
     financial_risk_approved = fields.Boolean(
         string="Financial Risk Approved", default=False
     )
+    generic_rules_approved = fields.Boolean(
+        string="Generic Rules Approved", default=False
+    )
 
     _order = "id desc"
 
@@ -583,6 +588,7 @@ class SubscriptionRequest(models.Model):
             "data_policy_approved": self.data_policy_approved,
             "internal_rules_approved": self.internal_rules_approved,
             "financial_risk_approved": self.financial_risk_approved,
+            "generic_rules_approved": self.generic_rules_approved,
         }
         return partner_vals
 
@@ -605,6 +611,7 @@ class SubscriptionRequest(models.Model):
             "data_policy_approved": self.data_policy_approved,
             "internal_rules_approved": self.internal_rules_approved,
             "financial_risk_approved": self.financial_risk_approved,
+            "generic_rules_approved": self.generic_rules_approved,
         }
         return partner_vals
 
@@ -634,6 +641,7 @@ class SubscriptionRequest(models.Model):
             "data_policy_approved": self.data_policy_approved,
             "internal_rules_approved": self.internal_rules_approved,
             "financial_risk_approved": self.financial_risk_approved,
+            "generic_rules_approved": self.generic_rules_approved,
         }
         return contact_vals
 

--- a/easy_my_coop/models/partner.py
+++ b/easy_my_coop/models/partner.py
@@ -184,6 +184,7 @@ class ResPartner(models.Model):
     data_policy_approved = fields.Boolean(string="Approved Data Policy")
     internal_rules_approved = fields.Boolean(string="Approved Internal Rules")
     financial_risk_approved = fields.Boolean(string="Approved Financial Risk")
+    generic_rules_approved = fields.Boolean(string="Approved generic rules")
 
     @api.multi
     @api.depends("subscription_request_ids.state")

--- a/easy_my_coop/views/res_company_view.xml
+++ b/easy_my_coop/views/res_company_view.xml
@@ -31,6 +31,9 @@
                     <field name="display_financial_risk_approval"/>
                     <field name="financial_risk_approval_required"/>
                     <field name="financial_risk_approval_text"/>
+                    <field name="display_generic_rules_approval"/>
+                    <field name="generic_rules_approval_required"/>
+                    <field name="generic_rules_approval_text"/>
                     <field name="send_confirmation_email"/>
                     <field name="send_capital_release_email"/>
                     <field name="send_certificate_email"/>

--- a/easy_my_coop/views/res_partner_view.xml
+++ b/easy_my_coop/views/res_partner_view.xml
@@ -53,13 +53,11 @@
                             <field name="gender"
                                    attrs="{'invisible':[('is_company','=',True)]}"/>
                         </group>
-                        <group name="approvals">
-                            <field name="internal_rules_approved"
-                                   attrs="{'invisible':[('member','=',False)]}"/>
-                            <field name="data_policy_approved"
-                                   attrs="{'invisible':[('member','=',False)]}"/>
-                            <field name="financial_risk_approved"
-                                   attrs="{'invisible':[('member','=',False)]}"/>
+                        <group name="approvals" attrs="{'invisible':[('cooperator','=',False)]}">
+                            <field name="internal_rules_approved"/>
+                            <field name="data_policy_approved"/>
+                            <field name="financial_risk_approved"/>
+                            <field name="generic_rules_approved"/>
                         </group>
                     </group>
                 </xpath>

--- a/easy_my_coop/views/subscription_request_view.xml
+++ b/easy_my_coop/views/subscription_request_view.xml
@@ -104,6 +104,7 @@
                             <field name="internal_rules_approved"/>
                             <field name="data_policy_approved"/>
                             <field name="financial_risk_approved"/>
+                            <field name="generic_rules_approved"/>
                         </group>
                     </group>
                     <notebook>

--- a/easy_my_coop_website/controllers/main.py
+++ b/easy_my_coop_website/controllers/main.py
@@ -227,6 +227,9 @@ class WebsiteSubscription(http.Controller):
                 "display_financial_risk": comp.display_financial_risk_approval,
                 "financial_risk_required": comp.financial_risk_approval_required,
                 "financial_risk_text": comp.financial_risk_approval_text,
+                "display_generic_rules": comp.display_generic_rules_approval,
+                "generic_rules_required": comp.generic_rules_approval_required,
+                "generic_rules_text": comp.generic_rules_approval_text,
             }
         )
         return values
@@ -455,6 +458,8 @@ class WebsiteSubscription(http.Controller):
 
         if kwargs.get("financial_risk_approved", "off") == "on":
             values["financial_risk_approved"] = True
+        if kwargs.get("generic_rules_approved", "off") == "on":
+            values["generic_rules_approved"] = True
 
         lastname = kwargs.get("lastname").upper()
         firstname = kwargs.get("firstname").title()

--- a/easy_my_coop_website/views/subscription_template.xml
+++ b/easy_my_coop_website/views/subscription_template.xml
@@ -448,6 +448,27 @@
 
                                 <br/>
 
+                                <div id="generic_rules_approved"
+                                     t-if="display_generic_rules"
+                                     t-attf-class="form-group">
+                                    <label class="col-md-3 col-sm-4 control-label"
+                                           for="generic_rules_approved">
+                                        Generic Rules
+                                    </label>
+                                    <div class="col-md-9 col-sm-8">
+                                        <div class="form-check">
+                                            <input type="checkbox"
+                                                   name="generic_rules_approved"
+                                                   class="form-check-input"
+                                                   t-att-required="generic_rules_required"
+                                                   t-att-checked="generic_rules_approved"/>
+                                            <div class="form-check-label">
+                                                <t t-raw="generic_rules_text"/>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+
                                 <div id="internal_rules_approved"
                                      t-if="display_internal_rules"
                                      t-attf-class="form-group">
@@ -511,26 +532,6 @@
                                     </div>
                                 </div>
 
-                                <div id="generic_rules_approved"
-                                     t-if="display_generic_rules"
-                                     t-attf-class="form-group">
-                                    <label class="col-md-3 col-sm-4 control-label"
-                                           for="generic_rules_approved">
-                                        Generic Rules
-                                    </label>
-                                    <div class="col-md-9 col-sm-8">
-                                        <div class="form-check">
-                                            <input type="checkbox"
-                                                   name="generic_rules_approved"
-                                                   class="form-check-input"
-                                                   t-att-required="generic_rules_required"
-                                                   t-att-checked="generic_rules_approved"/>
-                                            <div class="form-check-label">
-                                                <t t-raw="generic_rules_text"/>
-                                            </div>
-                                        </div>
-                                    </div>
-                                </div>
                                 <table style="margin-left:195px">
                                     <tr>
                                         <td width="80%">

--- a/easy_my_coop_website/views/subscription_template.xml
+++ b/easy_my_coop_website/views/subscription_template.xml
@@ -1009,6 +1009,27 @@
 
                                 <br/>
 
+                                <div id="generic_rules_approved"
+                                     t-if="display_generic_rules"
+                                     t-attf-class="form-group">
+                                    <label class="col-md-3 col-sm-4 control-label"
+                                           for="generic_rules_approved">
+                                        Generic Rules
+                                    </label>
+                                    <div class="col-md-9 col-sm-8">
+                                        <div class="form-check">
+                                            <input type="checkbox"
+                                                   name="generic_rules_approved"
+                                                   class="form-check-input"
+                                                   t-att-required="generic_rules_required"
+                                                   t-att-checked="generic_rules_approved"/>
+                                            <div class="form-check-label">
+                                                <t t-raw="generic_rules_text"/>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+
                                 <div id="data_policy_approved"
                                      t-if="display_data_policy"
                                      t-attf-class="form-group">

--- a/easy_my_coop_website/views/subscription_template.xml
+++ b/easy_my_coop_website/views/subscription_template.xml
@@ -511,6 +511,26 @@
                                     </div>
                                 </div>
 
+                                <div id="generic_rules_approved"
+                                     t-if="display_generic_rules"
+                                     t-attf-class="form-group">
+                                    <label class="col-md-3 col-sm-4 control-label"
+                                           for="generic_rules_approved">
+                                        Generic Rules
+                                    </label>
+                                    <div class="col-md-9 col-sm-8">
+                                        <div class="form-check">
+                                            <input type="checkbox"
+                                                   name="generic_rules_approved"
+                                                   class="form-check-input"
+                                                   t-att-required="generic_rules_required"
+                                                   t-att-checked="generic_rules_approved"/>
+                                            <div class="form-check-label">
+                                                <t t-raw="generic_rules_text"/>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
                                 <table style="margin-left:195px">
                                     <tr>
                                         <td width="80%">


### PR DESCRIPTION
add a generic approval field on the subscription form. This field has the option to be required or not, displayed or not. It also comes with his own text. The appears on the subscription request form and on the cooperator form.

corresponding task is [here](https://gestion.coopiteasy.be/web#id=6159&view_type=form&model=project.task&action=479)