### PR TITLE
[FIX] fix subscription request notification that was never sent

### DIFF
--- a/easy_my_coop/models/coop.py
+++ b/easy_my_coop/models/coop.py
@@ -88,7 +88,7 @@ class SubscriptionRequest(models.Model):
             cooperator.write({"cooperator": True})
         subscr_request = super(SubscriptionRequest, self).create(vals)
 
-        if self._send_confirmation_email():
+        if subscr_request._send_confirmation_email():
             mail_template_notif = subscr_request.get_mail_template_notif(is_company = False) #noqa
             mail_template_notif.send_mail(subscr_request.id)
 


### PR DESCRIPTION
Self in create function wasn't representing the record so the if statement was always false. This PR bring the situation to normal.

@enricostano I tag you for info to let you know that there is subscription request notification encounter an issue.