### PR TITLE
[12.0] easy_my_coop_website: fix street_name and house_number

### DIFF
--- a/easy_my_coop_website/controllers/main.py
+++ b/easy_my_coop_website/controllers/main.py
@@ -137,6 +137,8 @@ class WebsiteSubscription(http.Controller):
             if partner.bank_ids:
                 values["iban"] = partner.bank_ids[0].acc_number
             values["address"] = partner.street
+            # can fail if `street` is not formatted as `"{street}, {number}"`
+            [values["street_name"], values["house_number"]] = partner.street.split(", ", 1)
             values["zip_code"] = partner.zip
             values["city"] = partner.city
             values["country_id"] = partner.country_id.id

--- a/easy_my_coop_website/views/subscription_template.xml
+++ b/easy_my_coop_website/views/subscription_template.xml
@@ -956,7 +956,7 @@
                                                         name="house_number"
                                                         required="True"
                                                         t-att-readonly="logged"
-                                                        t-attf-value="#{street_number or ''}"
+                                                        t-attf-value="#{house_number or ''}"
                                                         placeholder="19"
                                                     />
                                                 </td>


### PR DESCRIPTION
[Task](https://gestion.coopiteasy.be/web#id=6857&view_type=form&model=project.task&action=479)

This bug was introduced by #114 

Current PR will fail if `street` is the like of "rue du travail 1" :
```python
[street_name, house_number] = street.split(", ", 1)
Traceback (most recent call last):
  File "<input>", line 1, in <module>
ValueError: not enough values to unpack (expected 2, got 1)
```
`street` should be formatted as `"{street}, {number}"`