### PR TITLE
Use any type of account for subscription request invoice

### DIFF
--- a/easy_my_coop_es/models/__init__.py
+++ b/easy_my_coop_es/models/__init__.py
@@ -1,1 +1,2 @@
+from . import company
 from . import subscription_request

--- a/easy_my_coop_es/models/company.py
+++ b/easy_my_coop_es/models/company.py
@@ -1,0 +1,10 @@
+from odoo import fields, models
+
+class ResCompany(models.Model):
+    _inherit = "res.company"
+
+    property_cooperator_account = fields.Many2one(
+        domain=[
+            ("deprecated", "=", False),
+        ],
+    )


### PR DESCRIPTION
In Spain we need to be able to use an account with `type` different than `receivable`, for instance account [558000](https://github.com/odoo/odoo/blob/12.0/addons/l10n_es/data/account.account.template-common.csv#L329).