### PR TITLE
Add readonly to member and coop_candidate in Partner form

### DIFF
--- a/easy_my_coop/models/partner.py
+++ b/easy_my_coop/models/partner.py
@@ -127,6 +127,7 @@ class ResPartner(models.Model):
     member = fields.Boolean(
         string="Effective cooperator",
         help="Check this box if this cooperator" " is an effective member.",
+        readonly=True,
     )
     coop_candidate = fields.Boolean(
         string="Cooperator candidate",

--- a/easy_my_coop/views/res_partner_view.xml
+++ b/easy_my_coop/views/res_partner_view.xml
@@ -50,6 +50,7 @@
                             />
                             <field
                                 name="coop_candidate"
+                                readonly="True"
                                 groups="easy_my_coop.group_easy_my_coop_user"
                             />
                             <field
@@ -59,6 +60,7 @@
                             />
                             <field
                                 name="member"
+                                readonly="True"
                                 groups="easy_my_coop.group_easy_my_coop_manager"
                             />
                             <field

--- a/easy_my_coop/views/res_partner_view.xml
+++ b/easy_my_coop/views/res_partner_view.xml
@@ -195,9 +195,7 @@
             <field
                 name="domain"
             >['|', ('cooperator','=',True), '|', ('member','=',True),('old_member','=', True)]</field>
-            <field
-                name="context"
-            >{'default_cooperator':1, 'search_default_cooperators':1}</field>
+            <field name="context">{'create':False}</field>
             <field name="help" type="html">
                 <p class="oe_view_nocontent_create">
                     Click to add a contact in your address book.
@@ -221,9 +219,7 @@
             <field name="view_type">form</field>
             <field name="view_mode">kanban,tree,form</field>
             <field name="domain">[('cooperator','=',True)]</field>
-            <field name="context">{'default_cooperator':1,
-                'search_default_cooperator_candidates':1}
-            </field>
+            <field name="context">{'create':False}</field>
             <field name="filter" eval="True" />
             <field name="help" type="html">
                 <p class="oe_view_nocontent_create">

--- a/easy_my_coop/views/res_partner_view.xml
+++ b/easy_my_coop/views/res_partner_view.xml
@@ -50,7 +50,6 @@
                             />
                             <field
                                 name="coop_candidate"
-                                readonly="True"
                                 groups="easy_my_coop.group_easy_my_coop_user"
                             />
                             <field
@@ -60,7 +59,6 @@
                             />
                             <field
                                 name="member"
-                                readonly="True"
                                 groups="easy_my_coop.group_easy_my_coop_manager"
                             />
                             <field


### PR DESCRIPTION
With these read only, we avoid creating a member without cooperator
number.
Also add a no create context to the Coop Candidate and Member act window.

Fixes: #154