### PR TITLE
[WIP] Implement custom Docker container CI via GitHub Actions

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -1,0 +1,18 @@
+name: Run pre-commit tests
+
+on:
+  push:
+    branches:
+      - 12.0
+  pull_request:
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: "3.6"
+      - name: Run pre-commit against all files
+        uses: pre-commit/action@v2.0.3

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,39 @@
+name: Test Odoo addons
+
+on:
+  push:
+    branches:
+      - 12.0
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    container: ghcr.io/coopiteasy/cie-odoo-ci:${{ matrix.container-tag }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - container-tag: 12.0-py3.6-main
+          - container-tag: 12.0-py3.7-main
+          - container-tag: 12.0-py3.8-main
+    services:
+      postgres:
+        image: postgres:12
+        env:
+          POSTGRES_USER: odoo
+          POSTGRES_PASSWORD: odoo
+          POSTGRES_DB: odoo
+        ports:
+          - 5432:5432
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Refresh gitaggregate
+        run: refresh_gitaggregate
+
+      - name: Install base Odoo
+        run: initialise_odoo .
+
+      - name: Run Odoo tests
+        run: run_tests .

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,8 +17,7 @@ exclude: |
   # You don't usually want a bot to modify your legal texts
   (LICENSE.*|COPYING.*)
 default_language_version:
-  # pylint-odoo does not (yet) support Python 3.10.
-  python: python3.7
+  python: python3
 repos:
   - repo: local
     hooks:


### PR DESCRIPTION
This PR tries to re-implement the CI functionality that was lost when Travis stopped being used.

It's a heavy WIP that is undertaken as a side project by a newbie cooperator (that's me). Ideally the work done here could be extracted into a template. vertical-cooperative was chosen as a guinea pig because it's small-medium-sized and doesn't have that many external dependencies.

edit (2021-12-15): This uses https://github.com/carmenbianca/cie-odoo-ci as Docker Container now.