### PR TITLE
Remove default key method added in auth_api_key

### DIFF
--- a/easy_my_coop_api/models/auth_api_key.py
+++ b/easy_my_coop_api/models/auth_api_key.py
@@ -10,14 +10,10 @@ from odoo import api, fields, models
 class AuthApiKey(models.Model):
     _inherit = "auth.api.key"
 
-    def _default_key(self):
-        return uuid.uuid4()
-
     # overloaded fields
     # required is set to false to allow for a computed field,
     # it will always be set.
     name = fields.Char(required=False, compute="_compute_name", store=True)
-    key = fields.Char(default=_default_key)
 
     @api.multi
     @api.depends("user_id")

--- a/setup/easy_my_coop_api/setup.py
+++ b/setup/easy_my_coop_api/setup.py
@@ -3,4 +3,7 @@ import setuptools
 setuptools.setup(
     setup_requires=['setuptools-odoo'],
     odoo_addon=True,
+    odoo_addons={
+        'depends_override': {
+            'auth_api_key': 'odoo12-addon-auth-api-key==12.0.2.1.1',
 )


### PR DESCRIPTION
We update the version of auth_api_key. Now this module includes the
default API key method to generate a default API key.

Related with: https://github.com/OCA/server-auth/pull/285