### PR TITLE
easy_my_coop: Set mail.template.easy_my_coop field to True on migration

### DIFF
--- a/easy_my_coop/migrations/12.0.1.0.0/end-migration.py
+++ b/easy_my_coop/migrations/12.0.1.0.0/end-migration.py
@@ -1,0 +1,21 @@
+import logging
+
+from openupgradelib import openupgrade
+
+logger = logging.getLogger("OpenUpgrade")
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    # Set all values 'easy_my_coop' to True for mail templates belonging to the
+    # easy_my_coop% modules. (T2772)
+    domain = [("model", "=", "mail.template"), ("module", "=like", "easy_my_coop%")]
+    templates = env["ir.model.data"].search(domain)
+    for entry in templates:
+        if not entry.easy_my_coop:
+            logger.info(
+                "Changing field 'easy_my_coop' from False to True in '{}'".format(
+                    "{}.{}".format(entry.module, entry.name)
+                )
+            )
+            entry.easy_my_coop = True

--- a/easy_my_coop/migrations/12.0.3.3.1/end-migration.py
+++ b/easy_my_coop/migrations/12.0.3.3.1/end-migration.py
@@ -1,3 +1,6 @@
+# Copyright 2022 Coop IT Easy SCRLfs
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
 import logging
 
 from openupgradelib import openupgrade
@@ -10,12 +13,15 @@ def migrate(env, version):
     # Set all values 'easy_my_coop' to True for mail templates belonging to the
     # easy_my_coop% modules. (T2772)
     domain = [("model", "=", "mail.template"), ("module", "=like", "easy_my_coop%")]
-    templates = env["ir.model.data"].search(domain)
+    model_data = env["ir.model.data"].search(domain)
+    templates = env["mail.template"].browse([md.res_id for md in model_data])
+    model_data_by_res_id = {md.res_id: md for md in model_data}
     for entry in templates:
         if not entry.easy_my_coop:
+            md = model_data_by_res_id[entry.id]
             logger.info(
                 "Changing field 'easy_my_coop' from False to True in '{}'".format(
-                    "{}.{}".format(entry.module, entry.name)
+                    "{}.{}".format(md.module, md.name)
                 )
             )
             entry.easy_my_coop = True


### PR DESCRIPTION
Previously, for some reason, these did not default to True, or somehow
lost their truthiness during migration from v9 to v12. Whatever the
case, this should make sure that doesn't happen.

Task: https://gestion.coopiteasy.be/web#id=5474&view_type=form&model=project.task&menu_id=338&action=479

Important to note: I haven't tested this, and will need some aid in figuring out how to test this.