### PR TITLE
[FIX] easy_my_coop_api: Fix syntax error in setup.py

### DIFF
--- a/setup/easy_my_coop_api/setup.py
+++ b/setup/easy_my_coop_api/setup.py
@@ -6,4 +6,6 @@ setuptools.setup(
     odoo_addons={
         'depends_override': {
             'auth_api_key': 'odoo12-addon-auth-api-key==12.0.2.1.1',
+        }
+    }
 )


### PR DESCRIPTION
Small error introduced in #183; broke pre-commit.

Not sure how black/pylint/autoflake/whatever didn't catch that error.