### PR TITLE
12.0 Fix cooperator kanban view 

### DIFF
--- a/easy_my_coop/models/partner.py
+++ b/easy_my_coop/models/partner.py
@@ -170,7 +170,7 @@ class ResPartner(models.Model):
     effective_date = fields.Date(
         sting="Effective Date", compute=_compute_effective_date, store=True
     )
-    representative = fields.Boolean(string="Legal Representative", default=True)
+    representative = fields.Boolean(string="Legal Representative")
     representative_of_member_company = fields.Boolean(
         string="Legal Representative of Member Company",
         store=True,
@@ -184,6 +184,13 @@ class ResPartner(models.Model):
     internal_rules_approved = fields.Boolean(string="Approved Internal Rules")
     financial_risk_approved = fields.Boolean(string="Approved Financial Risk")
     generic_rules_approved = fields.Boolean(string="Approved generic rules")
+
+    @api.onchange("parent_id")
+    def onchange_parent_id(self):
+        if len(self.parent_id) > 0:
+            self.representative = True
+        else:
+            self.representative = False
 
     @api.multi
     @api.depends("subscription_request_ids.state")

--- a/easy_my_coop/models/partner.py
+++ b/easy_my_coop/models/partner.py
@@ -170,7 +170,7 @@ class ResPartner(models.Model):
     effective_date = fields.Date(
         sting="Effective Date", compute=_compute_effective_date, store=True
     )
-    representative = fields.Boolean(string="Legal Representative")
+    representative = fields.Boolean(string="Legal Representative", default=True)
     representative_of_member_company = fields.Boolean(
         string="Legal Representative of Member Company",
         store=True,

--- a/easy_my_coop/views/res_partner_view.xml
+++ b/easy_my_coop/views/res_partner_view.xml
@@ -192,7 +192,7 @@
             <field name="view_mode">kanban,tree,form</field>
             <field
                 name="domain"
-            >['|', ('cooperator','=',True), '|', ('member','=',True),('old_member','=', True)]</field>
+            >['|', ('member','=',True),('old_member','=', True)]</field>
             <field name="context">{'create':False}</field>
             <field name="help" type="html">
                 <p class="oe_view_nocontent_create">
@@ -216,7 +216,9 @@
             <field name="res_model">res.partner</field>
             <field name="view_type">form</field>
             <field name="view_mode">kanban,tree,form</field>
-            <field name="domain">[('cooperator','=',True)]</field>
+            <field
+                name="domain"
+            >[('coop_candidate', '=',True)]</field>
             <field name="context">{'create':False}</field>
             <field name="filter" eval="True" />
             <field name="help" type="html">


### PR DESCRIPTION
Two Fixes:

1. Use correct domain for partner kanban views
  
    - remove coop_candidates from cooperators kanban view
    - keep only coop_candidates in coop_candidates view
    - remove legal reprentatives in both

2. Set legal representative as true by default

Task : https://gestion.coopiteasy.be/web#id=7798&view_type=form&model=project.task&action=479