### PR TITLE
[12.0] refactor all emails sent

### DIFF
--- a/easy_my_coop/models/account_invoice.py
+++ b/easy_my_coop/models/account_invoice.py
@@ -103,7 +103,7 @@ class AccountInvoice(models.Model):
 
         return True
 
-    def send_certificate_email(self, certificate_email_template, sub_reg_line):
+    def _send_certificate_email(self, certificate_email_template, sub_reg_line):
         if self.company_id.send_certificate_email:
             # we send the email with the certificate in attachment
             certificate_email_template.sudo().send_mail(self.partner_id.id, False)
@@ -132,7 +132,7 @@ class AccountInvoice(models.Model):
             if line.product_id.mail_template:
                 certificate_email_template = line.product_id.mail_template
 
-        self.send_certificate_email(certificate_email_template, sub_reg_line)
+        self._send_certificate_email(certificate_email_template, sub_reg_line)
 
         if self.company_id.create_user:
             self.create_user(self.partner_id)
@@ -186,13 +186,12 @@ class AccountInvoice(models.Model):
                 invoice.subscription_request.state = "cancelled"
         return True
 
-    def get_capital_release_mail_template(self):
-        template = "easy_my_coop.email_template_release_capital"
-        return self.env.ref(template, False)
+    def _get_capital_release_mail_template(self):
+        return self.env.ref("easy_my_coop.email_template_release_capital", False)
 
-    def send_capital_release_request(self):
+    def send_capital_release_request_email(self):
         if self.company_id.send_capital_release_email:
-            email_template = self.get_capital_release_mail_template()
+            email_template = self._get_capital_release_mail_template()
             # we send the email with the capital release request in attachment
             # TODO remove sudo() and give necessary access right
             email_template.sudo().send_mail(self.id, True)

--- a/easy_my_coop/models/account_invoice.py
+++ b/easy_my_coop/models/account_invoice.py
@@ -185,3 +185,15 @@ class AccountInvoice(models.Model):
             ):
                 invoice.subscription_request.state = "cancelled"
         return True
+
+    def get_capital_release_mail_template(self):
+        template = "easy_my_coop.email_template_release_capital"
+        return self.env.ref(template, False)
+
+    def send_capital_release_request(self):
+        if self.company_id.send_capital_release_email:
+            email_template = self.get_capital_release_mail_template()
+            # we send the email with the capital release request in attachment
+            # TODO remove sudo() and give necessary access right
+            email_template.sudo().send_mail(self.id, True)
+            self.sent = True

--- a/easy_my_coop/models/company.py
+++ b/easy_my_coop/models/company.py
@@ -97,7 +97,7 @@ class ResCompany(models.Model):
     )
     generic_rules_approval_text = fields.Html(
         translate=True,
-        help="Text to display aside the checkbox to approve the " "generic rules.",
+        help="Text to display aside the checkbox to approve the generic rules.",
     )
     send_certificate_email = fields.Boolean(
         string="Send certificate email", default=True
@@ -107,6 +107,9 @@ class ResCompany(models.Model):
     )
     send_capital_release_email = fields.Boolean(
         string="Send Capital Release email", default=True
+    )
+    send_waiting_list_email = fields.Boolean(
+        string="Send Waiting List email", default=True
     )
 
     @api.onchange("data_policy_approval_required")

--- a/easy_my_coop/models/company.py
+++ b/easy_my_coop/models/company.py
@@ -111,6 +111,12 @@ class ResCompany(models.Model):
     send_waiting_list_email = fields.Boolean(
         string="Send Waiting List email", default=True
     )
+    send_share_transfert_email = fields.Boolean(
+        string="Send Share Transfer Email", default=True
+    )
+    send_share_update_email = fields.Boolean(
+        string="Send Share Update Email", default=True
+    )
 
     @api.onchange("data_policy_approval_required")
     def onchange_data_policy_approval_required(self):

--- a/easy_my_coop/models/operation_request.py
+++ b/easy_my_coop/models/operation_request.py
@@ -288,17 +288,19 @@ class OperationRequest(models.Model):
     def get_share_update_mail_template(self):
         return self.env.ref("easy_my_coop.email_template_share_update", False)
 
-    def send_share_trans_mail(
+    def send_share_trans_mail(  # todo rename
         self, sub_register_line
-    ):  # Unused argument is used in synergie project. Do not remove.
-        cert_email_template = self.get_share_trans_mail_template()
-        cert_email_template.send_mail(self.partner_id_to.id, False)
+    ):  # fixme unused argument is used in synergie project. Do not remove.
+        if self.company_id.send_share_transfert_email:
+            cert_email_template = self.get_share_trans_mail_template()
+            cert_email_template.send_mail(self.partner_id_to.id, False)
 
-    def send_share_update_mail(
+    def send_share_update_mail(  # todo rename
         self, sub_register_line
-    ):  # Unused argument is used in synergie project. Do not remove.
-        cert_email_template = self.get_share_update_mail_template()
-        cert_email_template.send_mail(self.partner_id.id, False)
+    ):  # fixme unused argument is used in synergie project. Do not remove.
+        if self.company_id.send_share_update_email:
+            cert_email_template = self.get_share_update_mail_template()
+            cert_email_template.send_mail(self.partner_id.id, False)
 
     def get_subscription_register_vals(self, effective_date):
         return {

--- a/easy_my_coop/models/operation_request.py
+++ b/easy_my_coop/models/operation_request.py
@@ -282,24 +282,24 @@ class OperationRequest(models.Model):
                     )
                 )
 
-    def get_share_trans_mail_template(self):
+    def _get_share_transfert_mail_template(self):
         return self.env.ref("easy_my_coop.email_template_share_transfer", False)
 
-    def get_share_update_mail_template(self):
+    def _get_share_update_mail_template(self):
         return self.env.ref("easy_my_coop.email_template_share_update", False)
 
-    def send_share_trans_mail(  # todo rename
+    def _send_share_transfert_email(
         self, sub_register_line
     ):  # fixme unused argument is used in synergie project. Do not remove.
         if self.company_id.send_share_transfert_email:
-            cert_email_template = self.get_share_trans_mail_template()
+            cert_email_template = self._get_share_transfert_mail_template()
             cert_email_template.send_mail(self.partner_id_to.id, False)
 
-    def send_share_update_mail(  # todo rename
+    def _send_share_update_email(
         self, sub_register_line
     ):  # fixme unused argument is used in synergie project. Do not remove.
         if self.company_id.send_share_update_email:
-            cert_email_template = self.get_share_update_mail_template()
+            cert_email_template = self._get_share_update_mail_template()
             cert_email_template.send_mail(self.partner_id.id, False)
 
     def get_subscription_register_vals(self, effective_date):
@@ -414,6 +414,6 @@ class OperationRequest(models.Model):
 
         # send mail to the receiver
         if self.operation_type == "transfer":
-            self.send_share_trans_mail(sub_register_line)
+            self._send_share_transfert_email(sub_register_line)
 
-        self.send_share_update_mail(sub_register_line)
+        self._send_share_update_email(sub_register_line)

--- a/easy_my_coop/models/subscription_request.py
+++ b/easy_my_coop/models/subscription_request.py
@@ -201,7 +201,7 @@ class SubscriptionRequest(models.Model):
     state = fields.Selection(
         [
             ("draft", "Draft"),
-            ("block", "Blocked"),
+            ("block", "Blocked"),  # todo reword to blocked
             ("done", "Done"),
             ("waiting", "Waiting"),
             ("transfer", "Transfer"),
@@ -516,19 +516,6 @@ class SubscriptionRequest(models.Model):
         }
         return res
 
-    def get_capital_release_mail_template(self):
-        template = "easy_my_coop.email_template_release_capital"
-        return self.env.ref(template, False)
-
-    def send_capital_release_request(self, invoice):
-        email_template = self.get_capital_release_mail_template()
-
-        if self.company_id.send_capital_release_email:
-            # we send the email with the capital release request in attachment
-            # TODO remove sudo() and give necessary access right
-            email_template.sudo().send_mail(invoice.id, True)
-            invoice.sent = True
-
     def get_journal(self):
         return self.env.ref("easy_my_coop.subscription_journal")
 
@@ -568,8 +555,7 @@ class SubscriptionRequest(models.Model):
 
         # validate the capital release request
         invoice.action_invoice_open()
-
-        self.send_capital_release_request(invoice)
+        invoice.send_capital_release_request()
 
         return invoice
 

--- a/easy_my_coop/models/subscription_request.py
+++ b/easy_my_coop/models/subscription_request.py
@@ -96,7 +96,7 @@ class SubscriptionRequest(models.Model):
             cooperator.write({"cooperator": True})
         subscr_request = super(SubscriptionRequest, self).create(vals)
 
-        if subscr_request._send_confirmation_email():
+        if self.company_id.send_confirmation_email:
             mail_template_notif = subscr_request.get_mail_template_notif(
                 is_company=False
             )  # noqa
@@ -117,7 +117,8 @@ class SubscriptionRequest(models.Model):
                 vals["partner_id"] = cooperator.id
         subscr_request = super(SubscriptionRequest, self).create(vals)
 
-        if self._send_confirmation_email():
+        # fixme sends two emails
+        if self.company_id.send_confirmation_email:
             confirmation_mail_template = subscr_request.get_mail_template_notif(
                 is_company=True
             )
@@ -760,6 +761,3 @@ class SubscriptionRequest(models.Model):
         self.ensure_one()
         self.send_waiting_list_email()
         self.write({"state": "waiting"})
-
-    def _send_confirmation_email(self):
-        return self.company_id.send_confirmation_email

--- a/easy_my_coop/models/subscription_request.py
+++ b/easy_my_coop/models/subscription_request.py
@@ -75,7 +75,7 @@ class SubscriptionRequest(models.Model):
                     % request.share_product_id.name
                 )
 
-    def send_confirmation_email(self):
+    def _send_confirmation_email(self):
         if self.company_id.send_confirmation_email:
             mail_template_notif = self.get_mail_template_notif(
                 is_company=self.partner_id.is_company
@@ -107,7 +107,7 @@ class SubscriptionRequest(models.Model):
             cooperator.write({"cooperator": True})
 
         subscription_request = super(SubscriptionRequest, self).create(vals)
-        subscription_request.send_confirmation_email()
+        subscription_request._send_confirmation_email()
         return subscription_request
 
     @api.model
@@ -122,7 +122,7 @@ class SubscriptionRequest(models.Model):
                 vals = self.is_member(vals, cooperator)
                 vals["partner_id"] = cooperator.id
         subscription_request = super(SubscriptionRequest, self).create(vals)
-        subscription_request.send_confirmation_email()
+        subscription_request._send_confirmation_email()
         return subscription_request
 
     def check_empty_string(self, value):
@@ -555,7 +555,7 @@ class SubscriptionRequest(models.Model):
 
         # validate the capital release request
         invoice.action_invoice_open()
-        invoice.send_capital_release_request()
+        invoice.send_capital_release_request_email()
 
         return invoice
 
@@ -748,7 +748,7 @@ class SubscriptionRequest(models.Model):
         self.ensure_one()
         self.write({"state": "cancelled"})
 
-    def send_waiting_list_email(self):
+    def _send_waiting_list_email(self):
         if self.company_id.send_waiting_list_email:
             waiting_list_mail_template = self.env.ref(
                 "easy_my_coop.email_template_waiting_list", False
@@ -758,5 +758,5 @@ class SubscriptionRequest(models.Model):
     @api.multi
     def put_on_waiting_list(self):
         self.ensure_one()
-        self.send_waiting_list_email()
+        self._send_waiting_list_email()
         self.write({"state": "waiting"})

--- a/easy_my_coop/models/subscription_request.py
+++ b/easy_my_coop/models/subscription_request.py
@@ -748,13 +748,17 @@ class SubscriptionRequest(models.Model):
         self.ensure_one()
         self.write({"state": "cancelled"})
 
+    def send_waiting_list_email(self):
+        if self.company_id.send_waiting_list_email:
+            waiting_list_mail_template = self.env.ref(
+                "easy_my_coop.email_template_waiting_list", False
+            )
+            waiting_list_mail_template.send_mail(self.id, True)
+
     @api.multi
     def put_on_waiting_list(self):
         self.ensure_one()
-        waiting_list_mail_template = self.env.ref(
-            "easy_my_coop.email_template_waiting_list", False
-        )
-        waiting_list_mail_template.send_mail(self.id, True)
+        self.send_waiting_list_email()
         self.write({"state": "waiting"})
 
     def _send_confirmation_email(self):

--- a/easy_my_coop_loan/models/loan_issue_line.py
+++ b/easy_my_coop_loan/models/loan_issue_line.py
@@ -94,17 +94,17 @@ class LoanIssueLine(models.Model):
                 months=line.loan_issue_id.loan_term
             )
 
-    def get_loan_sub_mail_template(self):
+    def _get_loan_sub_mail_template(self):
         return self.env.ref("easy_my_coop_loan.loan_subscription_confirmation", False)
 
-    def get_loan_pay_req_mail_template(self):
+    def _get_loan_pay_req_mail_template(self):
         return self.env.ref("easy_my_coop_loan.loan_issue_payment_request", False)
 
     @api.model
     def create(self, vals):
         line = super(LoanIssueLine, self).create(vals)
 
-        confirmation_mail_template = line.get_loan_sub_mail_template()
+        confirmation_mail_template = line._get_loan_sub_mail_template()
         confirmation_mail_template.send_mail(line.id)
 
         return line
@@ -130,7 +130,7 @@ class LoanIssueLine(models.Model):
             raise UserError(_("You can only request payment for validated loans"))
 
         for line in self:
-            pay_req_mail_template = line.get_loan_pay_req_mail_template()
+            pay_req_mail_template = line._get_loan_pay_req_mail_template()
             pay_req_mail_template.send_mail(line.id)
             line.write({"state": "waiting"})
 


### PR DESCRIPTION
In order to solve [T1449 - C12b - EMC envoie le mail et certificat au coop, pas IWP](https://gestion.coopiteasy.be/web#id=4104&view_type=form&model=project.task&action=475&active_id=46), I needed to inventory all places where mails were set. En passant, i refactored to consistent names.

Review commit by commit to save headaches.

Aslo see: https://github.com/coopiteasy/investor-wallet-platform/pull/72