### PR TITLE
[IMP] emc_api: restrict access to records managed by api clients

### DIFF
--- a/easy_my_coop/models/subscription_request.py
+++ b/easy_my_coop/models/subscription_request.py
@@ -100,7 +100,7 @@ class SubscriptionRequest(models.Model):
             mail_template_notif = subscr_request.get_mail_template_notif(
                 is_company=False
             )  # noqa
-            mail_template_notif.send_mail(subscr_request.id)
+            mail_template_notif.sudo().send_mail(subscr_request.id)
 
         return subscr_request
 

--- a/easy_my_coop_api/__manifest__.py
+++ b/easy_my_coop_api/__manifest__.py
@@ -17,7 +17,10 @@
     "summary": """
         Open Easy My Coop to the world: RESTful API.
     """,
-    "data": ["views/external_id_mixin_views.xml"],
+    "data": [
+        "security/ir_rule.xml",
+        "views/external_id_mixin_views.xml",
+    ],
     "demo": ["demo/demo.xml"],
     "installable": True,
     "application": False,

--- a/easy_my_coop_api/models/external_id_mixin.py
+++ b/easy_my_coop_api/models/external_id_mixin.py
@@ -35,12 +35,9 @@ class ExternalIdMixin(models.AbstractModel):
     last_api_export_date = fields.Datetime(
         string="Last API Export Date", required=False, copy=False
     )
-
-    # only used to display and hide "Generate external ID" button
     external_id_generated = fields.Boolean(
         string="External ID Generated",
         default=False,
-        required=False,
         copy=False,
     )
 

--- a/easy_my_coop_api/models/subscription_request.py
+++ b/easy_my_coop_api/models/subscription_request.py
@@ -12,7 +12,8 @@ class SubscriptionRequest(models.Model):
 
     @api.multi
     def _timestamp_export(self):
-        self.write({"last_api_export_date": Datetime.now()})
-        self.filtered(lambda sr: not sr.first_api_export_date).write(
+        sudo_self = self.sudo()
+        sudo_self.write({"last_api_export_date": Datetime.now()})
+        sudo_self.filtered(lambda sr: not sr.first_api_export_date).write(
             {"first_api_export_date": Datetime.now()}
         )

--- a/easy_my_coop_api/security/ir_rule.xml
+++ b/easy_my_coop_api/security/ir_rule.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+     Copyright 2021 Coop IT Easy
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+-->
+<odoo>
+    <record id="rule_subscription_request_restrict_access_all" model="ir.rule">
+        <field
+            name="name"
+        >Restrict subscription request update and delete if managed outside of platform</field>
+        <field name="model_id" ref="easy_my_coop.model_subscription_request" />
+        <field name="perm_read" eval="False" />
+        <field name="perm_create" eval="False" />
+        <field name="perm_write" eval="True" />
+        <field name="perm_unlink" eval="True" />
+        <field name="domain_force">[("external_id_generated","=", False)]</field>
+    </record>
+    <record id="rule_account_invoice_access_all" model="ir.rule">
+        <field
+            name="name"
+        >Restrict invoice update and delete if managed outside of platform</field>
+        <field name="model_id" ref="account.model_account_invoice" />
+        <field name="perm_read" eval="False" />
+        <field name="perm_create" eval="False" />
+        <field name="perm_write" eval="True" />
+        <field name="perm_unlink" eval="True" />
+        <field name="domain_force">[("external_id_generated","=", False)]</field>
+    </record>
+    <record id="rule_account_payment_restrict_access_all" model="ir.rule">
+        <field
+            name="name"
+        >Restrict payment update and delete if managed outside of platform</field>
+        <field name="model_id" ref="account.model_account_payment" />
+        <field name="perm_read" eval="False" />
+        <field name="perm_create" eval="False" />
+        <field name="perm_write" eval="True" />
+        <field name="perm_unlink" eval="True" />
+        <field name="domain_force">[("external_id_generated","=", False)]</field>
+    </record>
+</odoo>

--- a/easy_my_coop_api/services/account_payment_service.py
+++ b/easy_my_coop_api/services/account_payment_service.py
@@ -29,7 +29,9 @@ class AccountPaymentService(Component):
     def create(self, **params):  # pylint: disable=method-required-super
         params = self._prepare_create(params)
         payment = self.env["account.payment"].create(params)
-        payment.post()
+        # sudo is needed to change state of invoice linked to a request
+        #  sent through the api
+        payment.sudo().post()
         return self._to_dict(payment)
 
     def _prepare_create(self, params):

--- a/easy_my_coop_api/services/subscription_request_service.py
+++ b/easy_my_coop_api/services/subscription_request_service.py
@@ -68,7 +68,8 @@ class SubscriptionRequestService(Component):
             raise wrapJsonException(
                 NotFound(_("No subscription request for id %s") % _id)
             )
-        sr.write(params)
+        # sudo is needed to update requests sent through the api
+        sr.sudo().write(params)
         return self._to_dict(sr)
 
     def validate(self, _id, **params):
@@ -81,7 +82,8 @@ class SubscriptionRequestService(Component):
             raise wrapJsonException(
                 BadRequest(_("Subscription request %s is not in draft state") % _id)
             )
-        invoice = sr.validate_subscription_request()
+        # sudo is needed to update requests sent through the api
+        invoice = sr.sudo().validate_subscription_request()
         invoice_service = self.work.component(usage="invoice")
         return invoice_service.get(invoice.get_api_external_id())
 

--- a/easy_my_coop_api/tests/common.py
+++ b/easy_my_coop_api/tests/common.py
@@ -28,6 +28,9 @@ class BaseEMCRestCase(BaseRestCase):
 
     def setUp(self):
         super().setUp()
+        # tests are run as res_users_manager_emc_demo with
+        #   emc manager access rights
+        self.uid = self.ref("easy_my_coop.res_users_manager_emc_demo")
         self.session = requests.Session()
 
     @classmethod
@@ -180,6 +183,8 @@ class BaseEMCRestCase(BaseRestCase):
         return headers
 
     def http_get(self, url, headers=None):
+        # api is called by res_users_manager_emc_demo with
+        #   emc manager access rights
         headers = self._add_api_key(headers)
         if url.startswith("/"):
             url = "http://{}:{}{}".format(HOST, PORT, url)
@@ -193,6 +198,8 @@ class BaseEMCRestCase(BaseRestCase):
         return json.loads(content)
 
     def http_post(self, url, data, headers=None):
+        # api is called by res_users_manager_emc_demo with
+        #   emc manager access rights
         headers = self._add_api_key(headers)
         if url.startswith("/"):
             url = "http://{}:{}{}".format(HOST, PORT, url)

--- a/easy_my_coop_api/tests/test_subscription_requests.py
+++ b/easy_my_coop_api/tests/test_subscription_requests.py
@@ -8,6 +8,7 @@ from datetime import timedelta
 from werkzeug.exceptions import BadRequest
 
 import odoo
+from odoo.exceptions import AccessError
 from odoo.fields import Date
 
 from odoo.addons.base_rest.controllers.main import _PseudoCollection
@@ -77,6 +78,12 @@ class TestSRController(BaseEMCRestCase):
         self.assertTrue(date_sr)
         self.assertTrue(self.demo_request_1.first_api_export_date)
         self.assertTrue(self.demo_request_1.last_api_export_date)
+
+    def test_fetched_request_cannot_be_updated(self):
+        external_id = self.demo_request_1.get_api_external_id()
+        self.sr_service.get(external_id)
+        with self.assertRaises(AccessError):
+            self.demo_request_1.email = "other@email.be"
 
     def test_route_get(self):
         external_id = self.demo_request_1.get_api_external_id()

--- a/easy_my_coop_connector/__manifest__.py
+++ b/easy_my_coop_connector/__manifest__.py
@@ -8,7 +8,7 @@
     "depends": ["easy_my_coop"],
     "author": "Coop IT Easy SCRLfs",
     "category": "Connector",
-    "website": "www.coopiteasy.be",
+    "website": "https://coopiteasy.be",
     "license": "AGPL-3",
     "summary": """
         Connect to Easy My Coop RESTful API.

--- a/setup/easy_my_coop_connector/odoo/addons/easy_my_coop_connector
+++ b/setup/easy_my_coop_connector/odoo/addons/easy_my_coop_connector
@@ -1,0 +1,1 @@
+../../../../easy_my_coop_connector

--- a/setup/easy_my_coop_connector/setup.py
+++ b/setup/easy_my_coop_connector/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)


### PR DESCRIPTION
# [T1445 - C11 - empêcher modifications sur iwp](https://gestion.coopiteasy.be/web#id=4100&view_type=form&model=project.task&action=475&active_id=46)

1st try: add an api user group and two ir.rules
- for api user group, domain: (1 = 1)
- for emc_user_group, domain: (external_id_generated = False)

This solution does not work because any group ir.rule bypasses
these rules, most notably, the rules from iwp to restrict access
to own structure.

This solution adds a global rules: if records were fetched or created
by actions resulting from api calls, no one can update or delete them.

The api bypasses these rules with .sudo.

A major drawback of this solution is that only Administrator will
be able to manipulate these records in the future. This may or may
not be good thing.