### PR TITLE
[FIX] rename_deprecated_modules.py: Enable merge_modules

### DIFF
--- a/rename_deprecated_modules.py
+++ b/rename_deprecated_modules.py
@@ -41,5 +41,5 @@ renamed_modules = {
 }
 
 _logger.info("rename easy_my_coop_x modules to cooperator_x")
-openupgrade.update_module_names(env.cr, renamed_modules.items())
+openupgrade.update_module_names(env.cr, renamed_modules.items(), merge_modules=True)
 env.cr.commit()


### PR DESCRIPTION
## Description

e.g., both easy_my_coop_be and easy_my_coop_taxshelter_report want to be renamed to l10n_be_cooperator. Without this flag, openupgradelib complains.

See here: https://github.com/OCA/openupgradelib/blob/7284922a0a4aa6fde29fb0fde1665b7e88240b6a/openupgradelib/openupgrade.py#L1404

