### PR TITLE
[FIX] fix subscription request name field

### DIFF
--- a/easy_my_coop/__manifest__.py
+++ b/easy_my_coop/__manifest__.py
@@ -7,7 +7,7 @@
 {
     "name": "Easy My Coop",
     "summary": "Manage your cooperative shares",
-    "version": "12.0.3.3.0",
+    "version": "12.0.3.3.1",
     "depends": [
         "base",
         "web",

--- a/easy_my_coop/migrations/12.0.3.3.1/pre-migration.py
+++ b/easy_my_coop/migrations/12.0.3.3.1/pre-migration.py
@@ -1,0 +1,6 @@
+def migrate(cr, version):
+    cr.execute(
+        "update subscription_request "
+        "set name = firstname || ' ' || lastname "
+        "where name is null or name = '';"
+    )

--- a/easy_my_coop/models/subscription_request.py
+++ b/easy_my_coop/models/subscription_request.py
@@ -34,7 +34,6 @@ class SubscriptionRequest(models.Model):
     _name = "subscription.request"
     _description = "Subscription Request"
     _inherit = ["mail.thread", "mail.activity.mixin"]
-    _rec_name = "lastname"
 
     def get_required_field(self):
         required_fields = _REQUIRED
@@ -144,6 +143,12 @@ class SubscriptionRequest(models.Model):
             return False
 
     @api.multi
+    @api.depends("firstname", "lastname")
+    def _compute_name(self):
+        for sub_request in self:
+            sub_request.name = " ".join([self.firstname, self.lastname])
+
+    @api.multi
     @api.depends("iban", "skip_control_ng")
     def _compute_validated_lines(self):
         for sub_request in self:
@@ -164,10 +169,12 @@ class SubscriptionRequest(models.Model):
         states={"draft": [("readonly", False)]},
     )
 
-    # deprecated, used to keep historic data
+    # previously, this was a normal field. it is now computed, and is used for
+    # the form title, and to allow for searching by any part of the full name.
     name = fields.Char(
         string="Name",
-        readonly=True,
+        compute="_compute_name",
+        store=True,
     )
     firstname = fields.Char(
         string="Firstname",

--- a/easy_my_coop/views/operation_request_view.xml
+++ b/easy_my_coop/views/operation_request_view.xml
@@ -127,7 +127,8 @@
                             context="{'default_is_operation': True, 'default_ordered_parts':quantity,'default_share_product_id': share_product_id, 'default_source':'operation'}"
                         >
                             <tree>
-                                <field name="name" />
+                                <field name="firstname" />
+                                <field name="lastname" />
                                 <field name="birthdate" />
                                 <field name="phone" />
                                 <field name="email" />
@@ -138,7 +139,6 @@
                                 <sheet>
                                     <group>
                                         <group>
-                                            <field name="name" />
                                             <field name="firstname" />
                                             <field name="lastname" />
                                             <field name="birthdate" />

--- a/easy_my_coop_website/controllers/main.py
+++ b/easy_my_coop_website/controllers/main.py
@@ -435,7 +435,6 @@ class WebsiteSubscription(http.Controller):
         lastname = kwargs.get("lastname").upper()
         firstname = kwargs.get("firstname").title()
 
-        values["name"] = firstname + " " + lastname
         values["lastname"] = lastname
         values["firstname"] = firstname
         values["birthdate"] = datetime.strptime(


### PR DESCRIPTION
*   make subscription.request.name a stored computed field to allow to search by any part of the full name.
*   fix subscription request views: use only firstname and lastname.

[task](https://gestion.coopiteasy.be/web#id=8357&view_type=form&model=project.task)