### PR TITLE
[12.0] Fix name stuff

### DIFF
--- a/easy_my_coop/i18n/ca_ES.po
+++ b/easy_my_coop/i18n/ca_ES.po
@@ -1092,7 +1092,7 @@ msgstr "Fes-te client/a"
 
 #. module: easy_my_coop
 #: model:ir.model.fields,field_description:easy_my_coop.field_subscription_request__birthdate
-msgid "Birthdate"
+msgid "Date of birth"
 msgstr "Data de naixement"
 
 #. module: easy_my_coop
@@ -1704,7 +1704,7 @@ msgstr ""
 
 #. module: easy_my_coop
 #: model:ir.model.fields,field_description:easy_my_coop.field_subscription_request__firstname
-msgid "Firstname"
+msgid "First name"
 msgstr ""
 
 #. module: easy_my_coop
@@ -1968,7 +1968,7 @@ msgstr "Última actualització el"
 
 #. module: easy_my_coop
 #: model:ir.model.fields,field_description:easy_my_coop.field_subscription_request__lastname
-msgid "Lastname"
+msgid "Last name"
 msgstr ""
 
 #. module: easy_my_coop

--- a/easy_my_coop/i18n/easy_my_coop.pot
+++ b/easy_my_coop/i18n/easy_my_coop.pot
@@ -655,7 +655,7 @@ msgstr ""
 
 #. module: easy_my_coop
 #: model:ir.model.fields,field_description:easy_my_coop.field_subscription_request__birthdate
-msgid "Birthdate"
+msgid "Date of birth"
 msgstr ""
 
 #. module: easy_my_coop
@@ -1262,7 +1262,7 @@ msgstr ""
 
 #. module: easy_my_coop
 #: model:ir.model.fields,field_description:easy_my_coop.field_subscription_request__firstname
-msgid "Firstname"
+msgid "First name"
 msgstr ""
 
 #. module: easy_my_coop
@@ -1521,7 +1521,7 @@ msgstr ""
 
 #. module: easy_my_coop
 #: model:ir.model.fields,field_description:easy_my_coop.field_subscription_request__lastname
-msgid "Lastname"
+msgid "Last name"
 msgstr ""
 
 #. module: easy_my_coop

--- a/easy_my_coop/i18n/es.po
+++ b/easy_my_coop/i18n/es.po
@@ -713,7 +713,7 @@ msgstr ""
 
 #. module: easy_my_coop
 #: model:ir.model.fields,field_description:easy_my_coop.field_subscription_request__birthdate
-msgid "Birthdate"
+msgid "Date of birth"
 msgstr ""
 
 #. module: easy_my_coop
@@ -1324,7 +1324,7 @@ msgstr ""
 
 #. module: easy_my_coop
 #: model:ir.model.fields,field_description:easy_my_coop.field_subscription_request__firstname
-msgid "Firstname"
+msgid "First name"
 msgstr ""
 
 #. module: easy_my_coop
@@ -1586,7 +1586,7 @@ msgstr ""
 
 #. module: easy_my_coop
 #: model:ir.model.fields,field_description:easy_my_coop.field_subscription_request__lastname
-msgid "Lastname"
+msgid "Last name"
 msgstr ""
 
 #. module: easy_my_coop

--- a/easy_my_coop/i18n/fr.po
+++ b/easy_my_coop/i18n/fr.po
@@ -1198,8 +1198,8 @@ msgstr "Le membre devient client automatiquement"
 
 #. module: easy_my_coop
 #: model:ir.model.fields,field_description:easy_my_coop.field_subscription_request__birthdate
-msgid "Birthdate"
-msgstr "Date de Naissance"
+msgid "Date of birth"
+msgstr "Date de naissance"
 
 #. module: easy_my_coop
 #: model_terms:ir.ui.view,arch_db:easy_my_coop.subscription_request_tree
@@ -1827,7 +1827,7 @@ msgstr "Approbation de politique de gestion des données"
 
 #. module: easy_my_coop
 #: model:ir.model.fields,field_description:easy_my_coop.field_subscription_request__firstname
-msgid "Firstname"
+msgid "First name"
 msgstr "Prénom"
 
 #. module: easy_my_coop
@@ -2100,7 +2100,7 @@ msgstr "Dernière mise à jour le"
 
 #. module: easy_my_coop
 #: model:ir.model.fields,field_description:easy_my_coop.field_subscription_request__lastname
-msgid "Lastname"
+msgid "Last name"
 msgstr "Nom de famille"
 
 #. module: easy_my_coop

--- a/easy_my_coop/i18n/fr_BE.po
+++ b/easy_my_coop/i18n/fr_BE.po
@@ -1205,7 +1205,7 @@ msgstr "Devenir client"
 
 #. module: easy_my_coop
 #: model:ir.model.fields,field_description:easy_my_coop.field_subscription_request__birthdate
-msgid "Birthdate"
+msgid "Date of birth"
 msgstr "Date de naissance"
 
 #. module: easy_my_coop
@@ -1835,7 +1835,7 @@ msgstr "Approbation de politique de gestion des données"
 
 #. module: easy_my_coop
 #: model:ir.model.fields,field_description:easy_my_coop.field_subscription_request__firstname
-msgid "Firstname"
+msgid "First name"
 msgstr "Prénom"
 
 #. module: easy_my_coop
@@ -2106,7 +2106,7 @@ msgstr "Dernière mise à jour le"
 
 #. module: easy_my_coop
 #: model:ir.model.fields,field_description:easy_my_coop.field_subscription_request__lastname
-msgid "Lastname"
+msgid "Last name"
 msgstr "Nom"
 
 #. module: easy_my_coop

--- a/easy_my_coop/i18n/nl_BE.po
+++ b/easy_my_coop/i18n/nl_BE.po
@@ -1105,7 +1105,7 @@ msgstr "Become cooperator"
 
 #. module: easy_my_coop
 #: model:ir.model.fields,field_description:easy_my_coop.field_subscription_request__birthdate
-msgid "Birthdate"
+msgid "Date of birth"
 msgstr "Geboortedatum"
 
 #. module: easy_my_coop
@@ -1745,8 +1745,8 @@ msgstr ""
 
 #. module: easy_my_coop
 #: model:ir.model.fields,field_description:easy_my_coop.field_subscription_request__firstname
-msgid "Firstname"
-msgstr "Firstname"
+msgid "First name"
+msgstr "Voornaam"
 
 #. module: easy_my_coop
 #: model:ir.model.fields,field_description:easy_my_coop.field_subscription_request__message_follower_ids
@@ -2015,8 +2015,8 @@ msgstr "Laatst bijgewerkt op"
 
 #. module: easy_my_coop
 #: model:ir.model.fields,field_description:easy_my_coop.field_subscription_request__lastname
-msgid "Lastname"
-msgstr "Lastname"
+msgid "Last name"
+msgstr "Achternaam"
 
 #. module: easy_my_coop
 #: model:ir.model.fields,field_description:easy_my_coop.field_res_partner__representative

--- a/easy_my_coop/models/subscription_request.py
+++ b/easy_my_coop/models/subscription_request.py
@@ -146,7 +146,9 @@ class SubscriptionRequest(models.Model):
     @api.depends("firstname", "lastname")
     def _compute_name(self):
         for sub_request in self:
-            sub_request.name = " ".join([self.firstname, self.lastname])
+            sub_request.name = " ".join(
+                part for part in (self.firstname, self.lastname) if part
+            )
 
     @api.multi
     @api.depends("iban", "skip_control_ng")

--- a/easy_my_coop/models/subscription_request.py
+++ b/easy_my_coop/models/subscription_request.py
@@ -179,19 +179,19 @@ class SubscriptionRequest(models.Model):
         store=True,
     )
     firstname = fields.Char(
-        string="Firstname",
+        string="First name",
         readonly=True,
         required=True,
         states={"draft": [("readonly", False)]},
     )
     lastname = fields.Char(
-        string="Lastname",
+        string="Last name",
         readonly=True,
         required=True,
         states={"draft": [("readonly", False)]},
     )
     birthdate = fields.Date(
-        string="Birthdate",
+        string="Date of birth",
         readonly=True,
         states={"draft": [("readonly", False)]},
     )


### PR DESCRIPTION
## Description

Fixes #297 

Previously, if either firstname or lastname was (unexpectedly) empty, an error would be thrown.
    
This PR uses approximately the same code approach as partner-contact/partner_firstname to compute the full name.

Also fixed the English source strings as clean-up.

