### PR TITLE
[12.0][FIX] Do not upper case lastname

### DIFF
--- a/easy_my_coop_website/controllers/main.py
+++ b/easy_my_coop_website/controllers/main.py
@@ -432,8 +432,8 @@ class WebsiteSubscription(http.Controller):
         if kwargs.get("generic_rules_approved", "off") == "on":
             values["generic_rules_approved"] = True
 
-        lastname = kwargs.get("lastname").upper()
-        firstname = kwargs.get("firstname").title()
+        lastname = kwargs.get("lastname")
+        firstname = kwargs.get("firstname")
 
         values["lastname"] = lastname
         values["firstname"] = firstname


### PR DESCRIPTION
## Description
Filling the `lastname` field in EMC forms, it will be transformed to upper case while creating the Subscription Request.

Is there any reason for this?

## Odoo task (if applicable)



## Checklist before approval

- [ ] Tests are present (or not needed).
- [ ] Credits/copyright have been changed correctly.
- [ ] (If a new module) Moving this to OCA has been considered.
