### PR TITLE
[FIX] form: always redirect to become_cooperator

### DIFF
--- a/easy_my_coop_website/controllers/main.py
+++ b/easy_my_coop_website/controllers/main.py
@@ -1,6 +1,7 @@
 import base64
 import re
 from datetime import datetime
+from urllib.parse import urljoin
 
 from odoo import http
 from odoo.http import request
@@ -253,7 +254,9 @@ class WebsiteSubscription(http.Controller):
 
         redirect = "easy_my_coop_website.becomecooperator"
         # redirect url to fall back on become coopererator in template redirection
-        values["redirect_url"] = request.httprequest.host_url + "become_cooperator"
+        values["redirect_url"] = urljoin(
+            request.httprequest.host_url, "become_cooperator"
+        )
 
         email = kwargs.get("email")
         is_company = kwargs.get("is_company") == "on"

--- a/easy_my_coop_website/controllers/main.py
+++ b/easy_my_coop_website/controllers/main.py
@@ -85,6 +85,9 @@ class WebsiteSubscription(http.Controller):
                 values[field] = kwargs.pop(field)
 
         values.update(kwargs=kwargs.items())
+
+        # redirect url to fall back on become coopererator in template redirection
+        values["redirect_url"] = request.httprequest.url
         return request.render("easy_my_coop_website.becomecooperator", values)
 
     @http.route(
@@ -249,6 +252,8 @@ class WebsiteSubscription(http.Controller):
         sub_req_obj = request.env["subscription.request"]
 
         redirect = "easy_my_coop_website.becomecooperator"
+        # redirect url to fall back on become coopererator in template redirection
+        values["redirect_url"] = request.httprequest.host_url + "become_cooperator"
 
         email = kwargs.get("email")
         is_company = kwargs.get("is_company") == "on"

--- a/easy_my_coop_website/views/subscription_template.xml
+++ b/easy_my_coop_website/views/subscription_template.xml
@@ -479,10 +479,16 @@
                                     t-attf-class="form-group"
                                     name="my_account_link_container"
                                 >
+                                <t t-if="redirect_url == null">
+                                    <t
+                                            t-set="redirect_url"
+                                            t-value="request.httprequest.url"
+                                        > </t>
+                                </t>
                                     <a
                                         class='btn btn-primary'
                                         t-if="not logged"
-                                        t-attf-href="/web/login?redirect=#{ request.httprequest.url }"
+                                        t-attf-href="/web/login?redirect=#{ redirect_url }"
                                         style="white-space: normal;"
                                     >
                                     Do you already have an account?


### PR DESCRIPTION
fix https://github.com/coopiteasy/vertical-cooperative/issues/295

Not based on 12.0-komunigi since it is not related to the komunigi refactoring.

This is a dirty fix to a structural issue in the controller (having two routes for the same template). 
Conceived with @remytms 