### PR TITLE
[FIX] fix subscription request state change in case of api error

### DIFF
--- a/easy_my_coop_connector/__manifest__.py
+++ b/easy_my_coop_connector/__manifest__.py
@@ -8,6 +8,7 @@
     "depends": [
         "easy_my_coop",
         "easy_my_coop_api_logs",
+        "queue_job",
     ],
     "author": "Coop IT Easy SCRLfs",
     "category": "Connector",

--- a/easy_my_coop_connector/models/account_payment.py
+++ b/easy_my_coop_connector/models/account_payment.py
@@ -34,6 +34,7 @@ class AccountPayment(models.Model):
                         )
                     )
 
+                # todo send via job queue
                 backend = self.env["emc.backend"].get_backend()
                 adapter = AccountPaymentAdapter(backend=backend)
                 external_id, external_record = adapter.create(payment)

--- a/easy_my_coop_connector/models/subscription_request.py
+++ b/easy_my_coop_connector/models/subscription_request.py
@@ -96,7 +96,10 @@ class SubscriptionRequest(models.Model):
     @api.multi
     def _set_state(self, state):
         super()._set_state(state)
-        if self.source == "emc_api":
+
+        api_subscription_requests = self.filtered(lambda sr: sr.source == "emc_api")
+        if api_subscription_requests:
             backend = self.env["emc.backend"].get_backend()
-            sr_adapter = SubscriptionRequestAdapter(backend=backend, record=self)
-            _, request_dict = sr_adapter.update({"state": state})
+            for sr in api_subscription_requests:
+                sr_adapter = SubscriptionRequestAdapter(backend=backend, record=sr)
+                sr_adapter.update({"state": state})

--- a/easy_my_coop_connector/models/subscription_request.py
+++ b/easy_my_coop_connector/models/subscription_request.py
@@ -64,6 +64,8 @@ class SubscriptionRequest(models.Model):
 
         if sr_binding:  # update request
             srequest = sr_binding.internal_id
+            # do not call _set_state : it would
+            # send a request to the backend.
             srequest.write(request_values)
         else:
             srequest = self.env["subscription.request"].create(request_values)

--- a/easy_my_coop_connector/models/subscription_request.py
+++ b/easy_my_coop_connector/models/subscription_request.py
@@ -92,49 +92,9 @@ class SubscriptionRequest(models.Model):
         _logger.info("fetch done.")
 
     @api.multi
-    def validate_subscription_request(self):
-        self.ensure_one()
-        invoice = super().validate_subscription_request()
-
+    def _set_state(self, state):
+        super()._set_state(state)
         if self.source == "emc_api":
             backend = self.env["emc.backend"].get_backend()
             sr_adapter = SubscriptionRequestAdapter(backend=backend, record=self)
-            _, request_dict = sr_adapter.update({"state": "done"})
-
-        return invoice
-
-    @api.multi
-    def block_subscription_request(self):
-        self.ensure_one()
-        super().block_subscription_request()
-        if self.source == "emc_api":
-            backend = self.env["emc.backend"].get_backend()
-            sr_adapter = SubscriptionRequestAdapter(backend=backend, record=self)
-            _, request_dict = sr_adapter.update({"state": "block"})
-
-    @api.multi
-    def unblock_subscription_request(self):
-        self.ensure_one()
-        super().unblock_subscription_request()
-        if self.source == "emc_api":
-            backend = self.env["emc.backend"].get_backend()
-            sr_adapter = SubscriptionRequestAdapter(backend=backend, record=self)
-            _, request_dict = sr_adapter.update({"state": "draft"})
-
-    @api.multi
-    def cancel_subscription_request(self):
-        self.ensure_one()
-        super().cancel_subscription_request()
-        if self.source == "emc_api":
-            backend = self.env["emc.backend"].get_backend()
-            sr_adapter = SubscriptionRequestAdapter(backend=backend, record=self)
-            _, request_dict = sr_adapter.update({"state": "cancelled"})
-
-    @api.multi
-    def put_on_waiting_list(self):
-        self.ensure_one()
-        super().put_on_waiting_list()
-        if self.source == "emc_api":
-            backend = self.env["emc.backend"].get_backend()
-            sr_adapter = SubscriptionRequestAdapter(backend=backend, record=self)
-            _, request_dict = sr_adapter.update({"state": "waiting"})
+            _, request_dict = sr_adapter.update({"state": state})

--- a/easy_my_coop_connector/readme/USAGE.rst
+++ b/easy_my_coop_connector/readme/USAGE.rst
@@ -20,3 +20,19 @@ The models are heavily influenced by the odoo connector:
 The <model> is responsible for the orchestration of these components.
 
 In the current implementation, only one backend is allowed.
+
+## Queue Jobs
+
+This module uses `queue_jobs` module, refer to the configuration
+documentation `here <https://github.com/OCA/queue/tree/12.0/queue_job>`.
+
+Most importantly :
+
+[options]
+(...)
+workers = x # greater than one
+server_wide_modules = web,queue_job
+
+(...)
+[queue_job]
+channels = root:2


### PR DESCRIPTION
## description

in case of subscription request state change, make the api call outside of the current transaction to avoid it to be rolled back in case of error.

## odoo task

[task](https://gestion.coopiteasy.be/web#id=8426&view_type=form&model=project.task)