### PR TITLE
12.0 komunigi install cooperator website recaptcha migration

### DIFF
--- a/cooperator_website/migrations/12.0.3.0.0/post-migration.py
+++ b/cooperator_website/migrations/12.0.3.0.0/post-migration.py
@@ -1,0 +1,11 @@
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+
+    module_ids = env["ir.module.module"].search(
+        [("name", "=", "cooperator_website_recaptcha"), ("state", "=", "uninstalled")]
+    )
+    if module_ids:
+        module_ids.button_install()

--- a/cooperator_website/migrations/12.0.3.0.0/pre-migration.py
+++ b/cooperator_website/migrations/12.0.3.0.0/pre-migration.py
@@ -1,0 +1,20 @@
+from openupgradelib import openupgrade
+
+renamed_view_xml_ids = (
+    (
+        "cooperator_website.captcha_template",
+        "cooperator_website_recaptcha.captcha_template",
+    ),
+)
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    env.cr.execute(
+        "delete from ir_ui_view where name ilike 'res.company.form.captcha%';"
+    )
+    env.cr.execute(
+        "delete from ir_ui_view where key = 'beesdoo_easy_my_coop.becomecooperator';"
+    )
+    env.cr.execute("delete from ir_ui_view where name ilike 'become%cooperator';")
+    openupgrade.rename_xmlids(env.cr, renamed_view_xml_ids)

--- a/cooperator_website_recaptcha/__manifest__.py
+++ b/cooperator_website_recaptcha/__manifest__.py
@@ -4,7 +4,7 @@
 {
     "name": "Cooperators Website Recaptcha",
     "summary": """
-        TODO""",
+        Add Google Recaptcha to Subscription Request Form""",
     "version": "12.0.1.0.0",
     "category": "Cooperative management",
     "website": "https://coopiteasy.be",

--- a/cooperator_website_recaptcha/readme/DESCRIPTION.rst
+++ b/cooperator_website_recaptcha/readme/DESCRIPTION.rst
@@ -1,0 +1,1 @@
+Add Google Recaptcha to Subscription Request Form

--- a/cooperator_website_recaptcha/views/subscription_template.xml
+++ b/cooperator_website_recaptcha/views/subscription_template.xml
@@ -17,7 +17,7 @@
         name="Become Cooperator"
     >
         <xpath expr="//t[@t-call='cooperator_website.rules_template']" position="after">
-            <t t-call="cooperator_website.captcha_template" />
+            <t t-call="cooperator_website_recaptcha.captcha_template" />
         </xpath>
     </template>
 
@@ -27,7 +27,7 @@
         name="Become Cooperator"
     >
         <xpath expr="//t[@t-call='cooperator_website.rules_template']" position="after">
-            <t t-call="cooperator_website.captcha_template" />
+            <t t-call="cooperator_website_recaptcha.captcha_template" />
         </xpath>
     </template>
 


### PR DESCRIPTION
migrating the split from `cooperator_website` to `cooperator_website_recaptcha` : 
-  remove view that calls `captcha_type` field that is now defined in `cooperator_website_recaptcha`. This view causes an error during the update all because of the missing field.
- install `cooperator_website_recaptcha`
