### PR TITLE
12.0 komunigi fix portal recaptcha migration

### DIFF
--- a/portal_recaptcha/__manifest__.py
+++ b/portal_recaptcha/__manifest__.py
@@ -2,7 +2,7 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 {
     "name": "Portal reCAPTCHA",
-    "version": "12.0.1.0.0",
+    "version": "12.0.1.0.1",
     "category": "Website",
     "depends": ["portal"],
     "author": "Tech Receptives, Coop IT Easy SCRLfs",

--- a/portal_recaptcha/migrations/12.0.1.0.1/pre-migration.py
+++ b/portal_recaptcha/migrations/12.0.1.0.1/pre-migration.py
@@ -1,4 +1,6 @@
 def migrate(cr, version):
+    # Uses a recursive query:
+    # https://www.postgresql.org/docs/current/queries-with.html
     cr.execute(
         """
     WITH RECURSIVE child_views AS (

--- a/portal_recaptcha/migrations/12.0.1.0.1/pre-migration.py
+++ b/portal_recaptcha/migrations/12.0.1.0.1/pre-migration.py
@@ -1,0 +1,33 @@
+def migrate(cr, version):
+    cr.execute(
+        """
+    WITH RECURSIVE child_views AS (
+        SELECT
+            id,
+            inherit_id,
+            name
+        FROM
+            ir_ui_view
+        WHERE
+            name ilike 'res_config_settings_view_form_inherit_website'
+        UNION
+        SELECT
+            i.id,
+            i.inherit_id,
+            i.name
+        FROM
+            ir_ui_view i
+            INNER JOIN child_views c ON c.id = i.inherit_id
+    )
+    DELETE FROM
+        ir_ui_view
+    WHERE
+        id IN (
+            SELECT
+                id
+            FROM
+                child_views
+        );
+        ;
+        """
+    )


### PR DESCRIPTION
Fix missing Website configuration menu issue. This was due to a migration script that archived the `res_config_settings_view_form_inherit_website` view, rather than deleting it. 
The new script deletes this view and the views that inherits from it.