### PR TITLE
[FIX] easy_my_coop: Fix name computation crash

### DIFF
--- a/easy_my_coop/models/subscription_request.py
+++ b/easy_my_coop/models/subscription_request.py
@@ -147,7 +147,7 @@ class SubscriptionRequest(models.Model):
     def _compute_name(self):
         for sub_request in self:
             sub_request.name = " ".join(
-                part for part in (self.firstname, self.lastname) if part
+                part for part in (sub_request.firstname, sub_request.lastname) if part
             )
 
     @api.multi

--- a/easy_my_coop/readme/newsfragments/330.bugfix.rst
+++ b/easy_my_coop/readme/newsfragments/330.bugfix.rst
@@ -1,0 +1,1 @@
+Fix name computation crash


### PR DESCRIPTION
Don't use value from self when looping over a list

## Description



## Odoo task (if applicable)

https://gestion.coopiteasy.be/web#id=8728&model=project.task&view_type=form&menu_id=

## Checklist before approval

- [ ] Tests are present (or not needed).
- [ ] Credits/copyright have been changed correctly.
- [ ] Change log snippet is present.
- [ ] (If a new module) Moving this to OCA has been considered.
