### PR TITLE
[ADD] update_partner_info to be modified by IWP DONOTMERGE

### DIFF
--- a/cooperator/models/subscription_request.py
+++ b/cooperator/models/subscription_request.py
@@ -61,6 +61,11 @@ class SubscriptionRequest(models.Model):
             vals["already_cooperator"] = True
         return vals
 
+    def update_partner_info(self):
+        # To be overiden to update specific partner information based
+        # on subscription request
+        return True
+
     @api.constrains("share_product_id", "is_company")
     def _check_share_available_to_user(self):
         for request in self:
@@ -696,6 +701,7 @@ class SubscriptionRequest(models.Model):
             raise UserError(_("Number of share must be greater than 0."))
         if self.partner_id:
             partner = self.partner_id
+            self.update_partner_info()
         else:
             partner = None
             domain = []


### PR DESCRIPTION
## Description
- based on an old tag because deployed in synergie server.
- adds an empty method update_partner_info to be overloaded. 
- Not to be merged


## Odoo task (if applicable)
https://gestion.coopiteasy.be/web#id=9449&model=project.task&view_type=form&menu_id=


## Checklist before approval

- [ ] Tests are present (or not needed).
- [ ] Credits/copyright have been changed correctly.
- [ ] Change log snippet is present.
- [ ] (If a new module) Moving this to OCA has been considered.
