### PR TITLE
[9.0][FIX] fix duplicated member field in view

### DIFF
--- a/easy_my_coop/models/partner.py
+++ b/easy_my_coop/models/partner.py
@@ -105,9 +105,12 @@ class ResPartner(models.Model):
     cooperator = fields.Boolean(string='Easy My Coop',
                                 help="Check this box if this contact is a"
                                 " cooperator(effective or not).")
-    member = fields.Boolean(string='Effective cooperator',
-                            help="Check this box if this cooperator"
-                            " is an effective member.")
+    member = fields.Boolean(
+        string='Effective cooperator',
+        help="Check this box if this cooperator is an effective member.",
+        readonly=True,
+        copy=False,
+    )
     coop_candidate = fields.Boolean(string="Cooperator candidate",
                                     compute="_compute_coop_candidate",
                                     store=True,

--- a/easy_my_coop/view/res_partner_view.xml
+++ b/easy_my_coop/view/res_partner_view.xml
@@ -25,7 +25,6 @@
 						<field name="company_register_number" readonly="True" attrs="{'invisible':[('is_company','=',False)]}"/>
 						<field name="coop_candidate" groups="easy_my_coop.group_energiris_user"/>
 						<field name="member" groups="easy_my_coop.group_energiris_super_manager"/>
-						<field name="member" readonly="True"/>
 						<field name="cooperator_type" attrs="{'invisible':[('member','=',False)]}"/>
 						<field name="effective_date" attrs="{'invisible':[('member','=',False)]}"/>
 					</group>


### PR DESCRIPTION
* remove duplicated member field in cooperator (res.partner) form view.
* set member field as read-only in the model (as is the case in 12.0).

fixes bug introduced in #158.