### PR TITLE
Removing _api_external_id journal from demo data

### DIFF
--- a/cooperator_api/demo/demo.xml
+++ b/cooperator_api/demo/demo.xml
@@ -30,11 +30,6 @@
         <field name="external_id_generated" eval="True" />
     </record>
 
-    <record id="cooperator.subscription_journal" model="account.journal">
-        <field name="_api_external_id">1</field>
-        <field name="external_id_generated" eval="True" />
-    </record>
-
     <record id="cooperator.account_equity_demo" model="account.account">
         <field name="_api_external_id">1</field>
         <field name="external_id_generated" eval="True" />


### PR DESCRIPTION
## Description

The cooperator accounting data is deleted in the tests context as is explained in the next commit message https://github.com/OCA/cooperative/commit/1ff4eddbadeb32eb1d4e29cc22d5f6bb3f0460b0 
Deleting this demo modification allows to install the dependency.

## Odoo task (if applicable)


## Checklist before approval

- [ ] Tests are present (or not needed).
- [ ] Credits/copyright have been changed correctly.
- [ ] Change log snippet is present.
- [ ] (If a new module) Moving this to OCA has been considered.
