### PR TITLE
[9.0][FIX] fix company cooperator web form prefill

### DIFF
--- a/easy_my_coop/controllers/main.py
+++ b/easy_my_coop/controllers/main.py
@@ -91,7 +91,21 @@ class WebsiteSubscription(http.Controller):
         # the subscriber is connected
         if request.env.user.login != 'public':
             values['logged'] = 'on'
-            partner = request.env.user.partner_id
+            partner = self._get_coop_partner_from_user(
+                request.env.user, is_company
+            )
+            if not partner:
+                if is_company:
+                    values["error_msg"] = _(
+                        "This account is not linked to a company. Please log "
+                        "out and try again."
+                    )
+                else:
+                    values["error_msg"] = _(
+                        "This account is linked to a company. Please log out "
+                        "and try again."
+                    )
+                return values
 
             if partner.member or partner.old_member:
                 values['already_cooperator'] = 'on'
@@ -211,6 +225,33 @@ class WebsiteSubscription(http.Controller):
             required_fields.remove(field)
         return required_fields
 
+    def _get_coop_partner_from_user(self, user, is_company):
+        """
+        Get the corresponding cooperator partner from the provided user.
+
+        is_company controls whether the cooperator should be a company or an
+        individual.
+        """
+        partner = user.partner_id
+        if is_company:
+            # the cooperator should be a company.
+            # there are several cases to handle:
+            # 1. the user is linked to a partner that is a company (normal
+            #    case).
+            # 2. the user is linked to a partner that is a representative of a
+            #    company (can happen if portal access was granted later).
+            # 3. the user is linked to a partner that is a person and not a
+            #    representative (not handled).
+            if partner.is_company:
+                return partner
+            if partner.representative:
+                return partner.parent_id
+            return partner.browse()
+        # the cooperator should be an individual.
+        if not partner.is_company:
+            return partner
+        return partner.get_representative()
+
     def validation(self, kwargs, logged, values, post_file):
         user_obj = request.env['res.users']
         sub_req_obj = request.env['subscription.request']
@@ -305,8 +346,10 @@ class WebsiteSubscription(http.Controller):
         # check the subscription's amount
         max_amount = company.subscription_maximum_amount
         if logged:
-            partner = request.env.user.partner_id
-            if partner.member:
+            partner = self._get_coop_partner_from_user(
+                request.env.user, is_company
+            )
+            if partner and partner.member:
                 max_amount = max_amount - partner.total_value
                 if company.unmix_share_type:
                     share = self.get_selected_share(kwargs)
@@ -372,9 +415,12 @@ class WebsiteSubscription(http.Controller):
 
         already_coop = False
         if logged:
-            partner = request.env.user.partner_id
-            values['partner_id'] = partner.id
-            already_coop = partner.member
+            partner = self._get_coop_partner_from_user(
+                request.env.user, is_company
+            )
+            if partner:
+                values['partner_id'] = partner.id
+                already_coop = partner.member
         elif kwargs.get("already_cooperator") == 'on':
             already_coop = True
 

--- a/easy_my_coop/i18n/fr.po
+++ b/easy_my_coop/i18n/fr.po
@@ -2509,6 +2509,18 @@ msgid "There is two different persons with the same national register number. Pl
 msgstr "There is two different persons with the same national register number. Please proceed to a merge before to continue"
 
 #. module: easy_my_coop
+#: code:addons/easy_my_coop/controllers/main.py:104
+#, python-format
+msgid "This account is linked to a company. Please log out and try again."
+msgstr "Ce compte est lié à une société. Veuillez vous déconnecter et réessayer."
+
+#. module: easy_my_coop
+#: code:addons/easy_my_coop/controllers/main.py:99
+#, python-format
+msgid "This account is not linked to a company. Please log out and try again."
+msgstr "Ce compte n'est pas lié à une société. Veuillez vous déconnecter et réessayer."
+
+#. module: easy_my_coop
 #: model:ir.model.fields,help:easy_my_coop.field_res_company_property_cooperator_account
 msgid "This account will be the default one as the receivable account for the cooperators"
 msgstr "This account will be the default one as the receivable account for the cooperators"


### PR DESCRIPTION
## description

fix the prefilling of the cooperator web form for companies when the logged-in user is a company representative (as opposed to a company itself).

## odoo task

[t12002](https://gestion.coopiteasy.be/web#model=project.task&id=12002)